### PR TITLE
feat(psm): evacuate/sweep + multi-guardian across Morpho + Beefy PSMs

### DIFF
--- a/echidna.yaml
+++ b/echidna.yaml
@@ -1,0 +1,9 @@
+testMode: property
+testLimit: 50000
+seqLen: 100
+deployer: "0x10000"
+sender: ["0x20000", "0x30000", "0x40000"]
+corpusDir: "echidna-corpus"
+codeSize: 0xFFFF
+# Use Foundry's remappings
+cryticArgs: ["--foundry-compile-all"]

--- a/solidity/contracts/BeefyVaultDDW.sol
+++ b/solidity/contracts/BeefyVaultDDW.sol
@@ -33,7 +33,14 @@ contract BeefyVaultPSM {
 
   bool public initialized;
 
+  bool public evacuated;
+  mapping(address => bool) public guardians;
+  uint256 public totalQueuedMAI;
+  uint256 public evacuationTime;
+  uint256 public constant SETTLEMENT_TIMEOUT = 30 days;
+
   error CallerIsNotOwner();
+  error CallerIsNotGuardianOrOwner();
   error ContractIsPaused();
   error InvalidAmount();
   error InvalidAmountAfterFee();
@@ -44,9 +51,12 @@ contract BeefyVaultPSM {
   error WithdrawalAlreadyExecutable();
   error AlreadyInitialized();
   error NewOwnerCannotBeZeroAddress();
+  error GuardianCannotBeZeroAddress();
   error WithdrawalNotAvailable();
   error NotEnoughLiquidity();
+  error NotEvacuated();
   error UpgradeNotScheduled();
+  error SettlementTooEarly();
 
   // Events
   event Deposited(address indexed _user, uint256 _amount);
@@ -63,6 +73,11 @@ contract BeefyVaultPSM {
   event MinimumFeesUpdated(uint256 _newMinimumDepositFee, uint256 _newMinimumWithdrawalFee);
   event FeesUpdated(uint256 _newDepositFee, uint256 _newWithdrawalFee);
   event MaxUpdated(uint256 _maxDeposit, uint256 _maxWithdraw);
+  event VaultEvacuated(address indexed _caller, uint256 _sharesRedeemed);
+  event Swept(address indexed _caller, uint256 _amount);
+  event RefundClaimed(address indexed _user, uint256 _maiAmount);
+  event GuardianUpdated(address _guardian, bool _enabled);
+  event RedeemFailed(bytes _reason);
 
   // target 0x9c4ec768c28520b50860ea7a15bd7213a9ff58bf
   constructor() {
@@ -74,12 +89,21 @@ contract BeefyVaultPSM {
     _;
   }
 
-  modifier pausable() {
-    if (paused[msg.sig] || stopped && block.timestamp > upgradeTime) revert ContractIsPaused();
+  modifier onlyGuardianOrOwner() {
+    if (msg.sender != owner && !guardians[msg.sender]) revert CallerIsNotGuardianOrOwner();
     _;
   }
 
-  function initialize(address _gem, uint256 _depositFee, uint256 _withdrawalFee) external onlyOwner {
+  modifier pausable() {
+    if (paused[msg.sig] || evacuated || (stopped && block.timestamp > upgradeTime)) revert ContractIsPaused();
+    _;
+  }
+
+  function initialize(
+    address _gem,
+    uint256 _depositFee,
+    uint256 _withdrawalFee
+  ) external onlyOwner {
     if (initialized) {
       revert AlreadyInitialized();
     }
@@ -104,7 +128,9 @@ contract BeefyVaultPSM {
   }
 
   // user deposits tokens (6 decimals), withdraws stable 18 decimals
-  function deposit(uint256 _amount) external pausable {
+  function deposit(
+    uint256 _amount
+  ) external pausable {
     if (_amount <= minimumDepositFee || _amount > maxDeposit) revert InvalidAmount();
     IERC20(underlying).transferFrom(msg.sender, address(this), _amount);
     uint256 _fee = calculateFee(_amount, true);
@@ -112,23 +138,29 @@ contract BeefyVaultPSM {
     totalStableLiquidity += _amount;
     IBeefy(gem).depositAll();
 
-    if (IERC20(MAI_ADDRESS).balanceOf(address(this)) < _amount * (10 ** (decimalDifference))) {
+    uint256 _maiOut = _amount * (10 ** (decimalDifference));
+    if (IERC20(MAI_ADDRESS).balanceOf(address(this)) < totalQueuedMAI + _maiOut) {
       revert InsufficientMAIBalance();
     }
-    IERC20(MAI_ADDRESS).transfer(msg.sender, _amount * (10 ** (decimalDifference)));
+    IERC20(MAI_ADDRESS).transfer(msg.sender, _maiOut);
     emit Deposited(msg.sender, _amount);
   }
 
-  function scheduleWithdraw(uint256 _amount) external pausable {
+  function scheduleWithdraw(
+    uint256 _amount
+  ) external pausable {
     if (withdrawalEpoch[msg.sender] != 0) {
       revert WithdrawalAlreadyScheduled();
     }
 
     uint256 _toWithdraw = _amount / (10 ** decimalDifference);
+    uint256 _fee = calculateFee(_toWithdraw, false);
+    if (_toWithdraw <= _fee) revert InvalidAmountAfterFee();
 
     if (_amount < minimumWithdrawalFee || _amount > maxWithdraw) revert InvalidAmount();
     if ((totalStableLiquidity - totalQueuedLiquidity) < _toWithdraw) revert NotEnoughLiquidity();
     totalQueuedLiquidity += _toWithdraw;
+    totalQueuedMAI += _amount;
     scheduledWithdrawalAmount[msg.sender] = _amount;
 
     IERC20(MAI_ADDRESS).transferFrom(msg.sender, address(this), _amount);
@@ -137,16 +169,21 @@ contract BeefyVaultPSM {
     emit WithdrawalScheduled(msg.sender, _amount);
   }
 
-  function _calculateAmountToShares(uint256 _amount) internal view returns (uint256 _shares) {
+  function _calculateAmountToShares(
+    uint256 _amount
+  ) internal view returns (uint256 _shares) {
     IBeefy _beef = IBeefy(gem);
     return (_amount * _beef.totalSupply()) / _beef.balance();
   }
 
-  function _calculateSharesToAmount(uint256 _shares) internal view returns (uint256 _amount) {
+  function _calculateSharesToAmount(
+    uint256 _shares
+  ) internal view returns (uint256 _amount) {
     IBeefy _beef = IBeefy(gem);
     return (_shares * _beef.balance()) / _beef.totalSupply();
   }
 
+  /// @notice Execute a scheduled withdrawal. Blocked post-evacuation by pausable modifier.
   function withdraw() external pausable {
     if (withdrawalEpoch[msg.sender] == 0 || block.timestamp < withdrawalEpoch[msg.sender]) {
       revert WithdrawalNotAvailable();
@@ -161,23 +198,25 @@ contract BeefyVaultPSM {
     if (_toWithdraw > totalStableLiquidity) {
       revert NotEnoughLiquidity();
     }
+
     IBeefy _beef = IBeefy(gem);
-    // get shares from an amount
     uint256 _freshShares = _calculateAmountToShares(_amount);
     uint256 _freshSharesRounded = (_freshShares / (10 ** decimalDifference));
-
     _beef.withdraw(_freshSharesRounded);
+    IERC20(underlying).transfer(msg.sender, _toWithdrawwFee);
+    _beef.depositAll();
 
     totalStableLiquidity -= _toWithdraw;
     totalQueuedLiquidity -= _toWithdraw;
-
-    IERC20(underlying).transfer(msg.sender, _toWithdrawwFee);
-    _beef.depositAll();
+    totalQueuedMAI -= _amount;
 
     emit Withdrawn(msg.sender, _amount);
   }
 
-  function calculateFee(uint256 _amount, bool _deposit) public view returns (uint256 _fee) {
+  function calculateFee(
+    uint256 _amount,
+    bool _deposit
+  ) public view returns (uint256 _fee) {
     if (_deposit) {
       _fee = _amount * depositFee / 10_000;
       _fee = _fee < minimumDepositFee ? minimumDepositFee : _fee;
@@ -188,6 +227,7 @@ contract BeefyVaultPSM {
   }
 
   function claimFees() external onlyOwner {
+    if (evacuated) return;
     IBeefy _beef = IBeefy(gem);
     // get total balance in underlying
     uint256 _shares = _beef.balanceOf(address(this));
@@ -202,12 +242,101 @@ contract BeefyVaultPSM {
     }
   }
 
-  function setPaused(bytes4 _selector, bool _paused) external onlyOwner {
+  /// @notice Emergency evacuation: withdraws all assets from the Beefy vault and freezes the contract
+  function evacuateVault() external onlyGuardianOrOwner {
+    evacuated = true;
+    if (evacuationTime == 0) evacuationTime = block.timestamp;
+
+    if (!stopped) {
+      stopped = true;
+      upgradeTime = block.timestamp + 2 days;
+    }
+
+    uint256 totalShares = IBeefy(gem).balanceOf(address(this));
+    if (totalShares > 0) {
+      try IBeefy(gem).withdrawAll() {}
+      catch (bytes memory reason) {
+        emit RedeemFailed(reason);
+      }
+    }
+
+    emit VaultEvacuated(msg.sender, totalShares);
+  }
+
+  /// @notice Allows users with pending scheduled withdrawals to recover their MAI after evacuation
+  function claimRefund() external {
+    if (!evacuated) revert NotEvacuated();
+    uint256 amount = scheduledWithdrawalAmount[msg.sender];
+    if (amount == 0) revert NoWithdrawalScheduled();
+
+    uint256 toRefund = amount / (10 ** decimalDifference);
+
+    scheduledWithdrawalAmount[msg.sender] = 0;
+    withdrawalEpoch[msg.sender] = 0;
+    totalQueuedLiquidity -= toRefund;
+    totalStableLiquidity -= toRefund;
+    totalQueuedMAI -= amount;
+
+    IERC20(MAI_ADDRESS).transfer(msg.sender, amount);
+    emit RefundClaimed(msg.sender, amount);
+  }
+
+  /// @notice Owner can force-settle a stale queued entry after SETTLEMENT_TIMEOUT
+  function forceSettle(
+    address _user
+  ) external onlyOwner {
+    if (!evacuated) revert NotEvacuated();
+    if (block.timestamp < evacuationTime + SETTLEMENT_TIMEOUT) revert SettlementTooEarly();
+    uint256 amount = scheduledWithdrawalAmount[_user];
+    if (amount == 0) revert NoWithdrawalScheduled();
+
+    uint256 toRefund = amount / (10 ** decimalDifference);
+
+    scheduledWithdrawalAmount[_user] = 0;
+    withdrawalEpoch[_user] = 0;
+    totalQueuedLiquidity -= toRefund;
+    totalStableLiquidity -= toRefund;
+    totalQueuedMAI -= amount;
+
+    // Send MAI directly to the user's address
+    IERC20(MAI_ADDRESS).transfer(_user, amount);
+    emit RefundClaimed(_user, amount);
+  }
+
+  /// @notice Deposits idle USDC in the contract into the Beefy vault with correct bookkeeping
+  function sweep() external onlyOwner {
+    if (evacuated) revert ContractIsPaused();
+
+    uint256 balance = IERC20(underlying).balanceOf(address(this));
+    if (balance == 0) revert InvalidAmount();
+
+    IBeefy(gem).depositAll();
+    totalStableLiquidity += balance;
+
+    emit Swept(msg.sender, balance);
+  }
+
+  /// @notice Adds or removes a guardian address for emergency evacuation
+  function setGuardian(
+    address _guardian,
+    bool _enabled
+  ) external onlyOwner {
+    if (_enabled && _guardian == address(0)) revert GuardianCannotBeZeroAddress();
+    guardians[_guardian] = _enabled;
+    emit GuardianUpdated(_guardian, _enabled);
+  }
+
+  function setPaused(
+    bytes4 _selector,
+    bool _paused
+  ) external onlyOwner {
     paused[_selector] = _paused;
     emit PauseEvent(msg.sender, _selector, _paused);
   }
 
-  function transferOwnership(address _newOwner) external onlyOwner {
+  function transferOwnership(
+    address _newOwner
+  ) external onlyOwner {
     if (_newOwner == address(0)) revert NewOwnerCannotBeZeroAddress();
     owner = _newOwner;
     emit OwnerUpdated(_newOwner);
@@ -220,8 +349,20 @@ contract BeefyVaultPSM {
     }
   }
 
-  function transferToken(address _token, address _to, uint256 _amount) external onlyOwner {
-    if (_token != gem || (stopped && block.timestamp > upgradeTime)) {
+  function transferToken(
+    address _token,
+    address _to,
+    uint256 _amount
+  ) external onlyOwner {
+    // MAI: reserve totalQueuedMAI
+    if (_token == MAI_ADDRESS) {
+      uint256 balance = IERC20(MAI_ADDRESS).balanceOf(address(this));
+      uint256 available = balance > totalQueuedMAI ? balance - totalQueuedMAI : 0;
+      if (_amount > available) revert NotEnoughLiquidity();
+    }
+    // underlying: NO reservation needed — users get MAI not USDC
+    bool isProtectedToken = _token == gem || (_token == underlying && evacuated);
+    if (!isProtectedToken || (stopped && block.timestamp > upgradeTime)) {
       IERC20(_token).transfer(_to, _amount);
     } else {
       revert UpgradeNotScheduled();
@@ -230,22 +371,36 @@ contract BeefyVaultPSM {
 
   function withdrawMAI() external onlyOwner {
     IERC20 _mai = IERC20(MAI_ADDRESS);
-    _mai.transfer(msg.sender, _mai.balanceOf(address(this)));
+    uint256 balance = _mai.balanceOf(address(this));
+
+    uint256 available = balance > totalQueuedMAI ? balance - totalQueuedMAI : 0;
+    if (available > 0) {
+      _mai.transfer(msg.sender, available);
+    }
   }
 
-  function updateMinimumFees(uint256 _newMinimumDepositFee, uint256 _newMinimumWithdrawalFee) external onlyOwner {
+  function updateMinimumFees(
+    uint256 _newMinimumDepositFee,
+    uint256 _newMinimumWithdrawalFee
+  ) external onlyOwner {
     minimumDepositFee = _newMinimumDepositFee;
     minimumWithdrawalFee = _newMinimumWithdrawalFee;
     emit MinimumFeesUpdated(_newMinimumDepositFee, _newMinimumWithdrawalFee);
   }
 
-  function updateFeesBP(uint256 _newDepositFee, uint256 _newWithdrawalFee) external onlyOwner {
+  function updateFeesBP(
+    uint256 _newDepositFee,
+    uint256 _newWithdrawalFee
+  ) external onlyOwner {
     depositFee = _newDepositFee;
     withdrawalFee = _newWithdrawalFee;
     emit FeesUpdated(_newDepositFee, _newWithdrawalFee);
   }
 
-  function updateMax(uint256 _maxDeposit, uint256 _maxWithdraw) external onlyOwner {
+  function updateMax(
+    uint256 _maxDeposit,
+    uint256 _maxWithdraw
+  ) external onlyOwner {
     maxDeposit = _maxDeposit;
     maxWithdraw = _maxWithdraw;
     emit MaxUpdated(_maxDeposit, _maxWithdraw);

--- a/solidity/contracts/BeefyVaultPSMMainnet.sol
+++ b/solidity/contracts/BeefyVaultPSMMainnet.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {IFly} from '../interfaces/IFly.sol';
+import {IBeefy} from '../interfaces/IBeefy.sol';
 import {IERC20} from '../interfaces/IERC20.sol';
 
-contract MorphoVaultPSM {
+/// @title BeefyVaultPSMMainnet
+/// @notice PSM for Ethereum Mainnet with configurable MAI address and minimum reserves feature
+/// @dev Based on BeefyVaultDDW with added minimum reserves functionality
+contract BeefyVaultPSMMainnet {
   uint256 public constant MAX_INT =
     115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_935;
+
+  // Configurable MAI address (not hardcoded like base chain version)
   address public MAI_ADDRESS;
 
   uint256 public totalStableLiquidity;
@@ -15,16 +20,20 @@ contract MorphoVaultPSM {
   uint256 public withdrawalFee;
   uint256 public minimumDepositFee;
   uint256 public minimumWithdrawalFee;
+  uint256 public decimalDifference;
+
+  // Minimum reserves - absolute amount in underlying decimals (6 for USDC)
+  uint256 public minimumReserves;
 
   uint256 public maxDeposit;
   uint256 public maxWithdraw;
   uint256 public upgradeTime;
-  uint256 public decimalDifference;
 
   address public underlying;
   address public owner;
   address public gem;
 
+  // user deposits stable, schedules withdrawal of shares
   mapping(address => uint256) public withdrawalEpoch;
   mapping(address => uint256) public scheduledWithdrawalAmount;
 
@@ -36,8 +45,11 @@ contract MorphoVaultPSM {
   bool public evacuated;
   mapping(address => bool) public guardians;
   uint256 public totalQueuedMAI;
+  uint256 public evacuationTime;
+  uint256 public constant SETTLEMENT_TIMEOUT = 30 days;
 
   error CallerIsNotOwner();
+  error CallerIsNotGuardianOrOwner();
   error ContractIsPaused();
   error InvalidAmount();
   error InvalidAmountAfterFee();
@@ -48,13 +60,14 @@ contract MorphoVaultPSM {
   error WithdrawalAlreadyExecutable();
   error AlreadyInitialized();
   error NewOwnerCannotBeZeroAddress();
+  error GuardianCannotBeZeroAddress();
   error WithdrawalNotAvailable();
   error NotEnoughLiquidity();
-  error UpgradeNotScheduled();
-  error MAIAddressCannotBeZero();
   error NotEvacuated();
-  error CallerIsNotGuardianOrOwner();
-  error GuardianCannotBeZeroAddress();
+  error UpgradeNotScheduled();
+  error SettlementTooEarly();
+  error MAIAddressCannotBeZero();
+  error MinimumReservesBreached();
 
   // Events
   event Deposited(address indexed _user, uint256 _amount);
@@ -71,6 +84,7 @@ contract MorphoVaultPSM {
   event MinimumFeesUpdated(uint256 _newMinimumDepositFee, uint256 _newMinimumWithdrawalFee);
   event FeesUpdated(uint256 _newDepositFee, uint256 _newWithdrawalFee);
   event MaxUpdated(uint256 _maxDeposit, uint256 _maxWithdraw);
+  event MinimumReservesUpdated(uint256 _oldMinimumReserves, uint256 _newMinimumReserves);
   event VaultEvacuated(address indexed _caller, uint256 _sharesRedeemed);
   event Swept(address indexed _caller, uint256 _amount);
   event RefundClaimed(address indexed _user, uint256 _maiAmount);
@@ -96,6 +110,11 @@ contract MorphoVaultPSM {
     _;
   }
 
+  /// @notice Initialize the PSM with vault and fee configuration
+  /// @param _gem The Beefy vault address
+  /// @param _depositFee Deposit fee in basis points
+  /// @param _withdrawalFee Withdrawal fee in basis points
+  /// @param _maiAddress The MAI token address for this chain
   function initialize(
     address _gem,
     uint256 _depositFee,
@@ -108,52 +127,51 @@ contract MorphoVaultPSM {
     if (_maiAddress == address(0)) {
       revert MAIAddressCannotBeZero();
     }
-    depositFee = _depositFee;
-    withdrawalFee = _withdrawalFee;
-    minimumDepositFee = 0;
+
+    depositFee = _depositFee; // basis points
+    withdrawalFee = _withdrawalFee; // basis points
+    minimumDepositFee = 1_000_000; // this is 1 dollar (in 6 decimals)
     minimumWithdrawalFee = 1_000_000; // 1 dollar
 
-    IFly _beef = IFly(_gem);
+    IBeefy _beef = IBeefy(_gem);
 
     maxDeposit = 1e24; // 1 million ether
     maxWithdraw = 1e24; // 1 million ether
-    underlying = _beef.asset();
+    underlying = _beef.want();
     decimalDifference = uint256(_beef.decimals() - IERC20(underlying).decimals());
     gem = _gem;
     MAI_ADDRESS = _maiAddress;
+    minimumReserves = 0; // Default to 0, owner can set later
     initialized = true;
-    approveGem();
+    approveBeef();
   }
 
-  function approveGem() public {
+  function approveBeef() public {
     IERC20(underlying).approve(gem, MAX_INT);
   }
 
-  /// @notice User deposits tokens with 18 decimals and withdraws stablecoin
-  /// @param _amount The amount of tokens to deposit
+  /// @notice User deposits underlying tokens and receives MAI
+  /// @param _amount The amount of underlying tokens to deposit (6 decimals for USDC)
   function deposit(
     uint256 _amount
   ) external pausable {
     if (_amount <= minimumDepositFee || _amount > maxDeposit) revert InvalidAmount();
-    IERC20 iunder = IERC20(underlying);
-    iunder.transferFrom(msg.sender, address(this), _amount);
+    IERC20(underlying).transferFrom(msg.sender, address(this), _amount);
     uint256 _fee = calculateFee(_amount, true);
-
-    IFly(gem).deposit(iunder.balanceOf(address(this)), address(this));
-
     _amount = _amount - _fee;
     totalStableLiquidity += _amount;
+    IBeefy(gem).depositAll();
 
-    uint256 scaledAmount = _amount * (10 ** decimalDifference);
-    if (IERC20(MAI_ADDRESS).balanceOf(address(this)) < scaledAmount) {
+    uint256 _maiOut = _amount * (10 ** (decimalDifference));
+    if (IERC20(MAI_ADDRESS).balanceOf(address(this)) < totalQueuedMAI + _maiOut) {
       revert InsufficientMAIBalance();
     }
-    IERC20(MAI_ADDRESS).transfer(msg.sender, scaledAmount);
+    IERC20(MAI_ADDRESS).transfer(msg.sender, _maiOut);
     emit Deposited(msg.sender, _amount);
   }
 
-  /// @notice Schedules a withdrawal of stablecoin
-  /// @param _amount The amount of stablecoin to withdraw
+  /// @notice Schedule a withdrawal of MAI for underlying tokens
+  /// @param _amount The amount of MAI to withdraw (18 decimals)
   function scheduleWithdraw(
     uint256 _amount
   ) external pausable {
@@ -161,21 +179,45 @@ contract MorphoVaultPSM {
       revert WithdrawalAlreadyScheduled();
     }
 
-    if (_amount < minimumWithdrawalFee || _amount > maxWithdraw) revert InvalidAmount();
-
     uint256 _toWithdraw = _amount / (10 ** decimalDifference);
     uint256 _fee = calculateFee(_toWithdraw, false);
     if (_toWithdraw <= _fee) revert InvalidAmountAfterFee();
-    if ((totalStableLiquidity - totalQueuedLiquidity) < _toWithdraw) revert NotEnoughLiquidity();
+
+    if (_amount < minimumWithdrawalFee || _amount > maxWithdraw) revert InvalidAmount();
+
+    // Check minimum reserves constraint
+    // Available = totalStableLiquidity - totalQueuedLiquidity
+    // After this withdrawal: Available - _toWithdraw must be >= minimumReserves
+    uint256 _availableLiquidity = totalStableLiquidity - totalQueuedLiquidity;
+    if (_availableLiquidity < minimumReserves + _toWithdraw) {
+      revert MinimumReservesBreached();
+    }
+
     totalQueuedLiquidity += _toWithdraw;
     totalQueuedMAI += _amount;
     scheduledWithdrawalAmount[msg.sender] = _amount;
+
     IERC20(MAI_ADDRESS).transferFrom(msg.sender, address(this), _amount);
+
     withdrawalEpoch[msg.sender] = block.timestamp + 3 days;
     emit WithdrawalScheduled(msg.sender, _amount);
   }
 
-  /// @notice Withdraws scheduled stablecoin after the withdrawal epoch
+  function _calculateAmountToShares(
+    uint256 _amount
+  ) internal view returns (uint256 _shares) {
+    IBeefy _beef = IBeefy(gem);
+    return (_amount * _beef.totalSupply()) / _beef.balance();
+  }
+
+  function _calculateSharesToAmount(
+    uint256 _shares
+  ) internal view returns (uint256 _amount) {
+    IBeefy _beef = IBeefy(gem);
+    return (_shares * _beef.balance()) / _beef.totalSupply();
+  }
+
+  /// @notice Execute a scheduled withdrawal. Blocked post-evacuation by pausable modifier.
   function withdraw() external pausable {
     if (withdrawalEpoch[msg.sender] == 0 || block.timestamp < withdrawalEpoch[msg.sender]) {
       revert WithdrawalNotAvailable();
@@ -190,25 +232,24 @@ contract MorphoVaultPSM {
     if (_toWithdraw > totalStableLiquidity) {
       revert NotEnoughLiquidity();
     }
-    IFly vault = IFly(gem);
+
+    IBeefy _beef = IBeefy(gem);
+    uint256 _freshShares = _calculateAmountToShares(_amount);
+    uint256 _freshSharesRounded = (_freshShares / (10 ** decimalDifference));
+    _beef.withdraw(_freshSharesRounded);
+    IERC20(underlying).transfer(msg.sender, _toWithdrawwFee);
+    _beef.depositAll();
 
     totalStableLiquidity -= _toWithdraw;
     totalQueuedLiquidity -= _toWithdraw;
     totalQueuedMAI -= _amount;
 
-    // This would withdraw and transfer to user
-    vault.withdraw(_toWithdrawwFee, msg.sender, address(this));
-    uint256 _remaining = IERC20(underlying).balanceOf(address(this));
-    if (_remaining > 0) {
-      vault.deposit(_remaining, address(this));
-    }
-
     emit Withdrawn(msg.sender, _amount);
   }
 
-  /// @notice Calculates the fee for deposit or withdrawal
-  /// @param _amount The amount to calculate the fee on
-  /// @param _deposit Boolean indicating if the fee is for a deposit (true) or withdrawal (false)
+  /// @notice Calculate the fee for a deposit or withdrawal
+  /// @param _amount The amount to calculate fee on (in underlying decimals)
+  /// @param _deposit True for deposit fee, false for withdrawal fee
   /// @return _fee The calculated fee
   function calculateFee(
     uint256 _amount,
@@ -223,33 +264,68 @@ contract MorphoVaultPSM {
     }
   }
 
-  /// @notice Allows the owner to claim fees accumulated in the contract
-  function claimFees() external onlyOwner {
-    IFly _beef = IFly(gem);
+  /// @notice Returns the amount available for new withdrawal scheduling
+  /// @return The amount in underlying decimals (6 for USDC) that can be withdrawn
+  function availableForWithdrawal() public view returns (uint256) {
+    uint256 _availableLiquidity = totalStableLiquidity - totalQueuedLiquidity;
+    if (_availableLiquidity <= minimumReserves) {
+      return 0;
+    }
+    uint256 _available = _availableLiquidity - minimumReserves;
+    // Clamp to amounts that survive the withdrawal fee floor
+    uint256 _fee = calculateFee(_available, false);
+    if (_available <= _fee) {
+      return 0;
+    }
+    return _available;
+  }
 
-    uint256 totalShares = _beef.balanceOf(address(this));
-    uint256 _totalStoredInUsd = _beef.convertToAssets(totalShares);
+  /// @notice Returns the amount available for withdrawal scheduling in MAI decimals
+  /// @return The amount in MAI decimals (18) that can be withdrawn
+  function availableForWithdrawalInMAI() external view returns (uint256) {
+    return availableForWithdrawal() * (10 ** decimalDifference);
+  }
+
+  /// @notice Owner can claim accumulated fees (yield above liabilities)
+  function claimFees() external onlyOwner {
+    if (evacuated) return;
+    IBeefy _beef = IBeefy(gem);
+    // get total balance in underlying
+    uint256 _shares = _beef.balanceOf(address(this));
+    uint256 _totalStoredInUsd = _calculateSharesToAmount(_shares);
+    uint256 _totalStableShares = _calculateAmountToShares(totalStableLiquidity);
     if (_totalStoredInUsd > totalStableLiquidity) {
       uint256 _fees = (_totalStoredInUsd - totalStableLiquidity); // in USDC
-      _beef.withdraw(_totalStoredInUsd - totalStableLiquidity, msg.sender, address(this));
+      _beef.withdraw(_shares - _totalStableShares);
       emit FeesWithdrawn(msg.sender, _fees);
-      // directly sends the owner the amount
+      IERC20 usdc = IERC20(underlying);
+      usdc.transfer(msg.sender, usdc.balanceOf(address(this)));
     }
   }
 
-  /// @notice Emergency evacuation: withdraws all assets from the Morpho vault and freezes the contract
+  /// @notice Set the minimum reserves that must remain available in the PSM
+  /// @param _minimumReserves The minimum amount in underlying token decimals (6 for USDC)
+  function setMinimumReserves(
+    uint256 _minimumReserves
+  ) external onlyOwner {
+    uint256 _oldMinimumReserves = minimumReserves;
+    minimumReserves = _minimumReserves;
+    emit MinimumReservesUpdated(_oldMinimumReserves, _minimumReserves);
+  }
+
+  /// @notice Emergency evacuation: withdraws all assets from the Beefy vault and freezes the contract
   function evacuateVault() external onlyGuardianOrOwner {
     evacuated = true;
+    if (evacuationTime == 0) evacuationTime = block.timestamp;
 
     if (!stopped) {
       stopped = true;
       upgradeTime = block.timestamp + 2 days;
     }
 
-    IFly vault = IFly(gem);
-    uint256 totalShares = vault.balanceOf(address(this));
+    uint256 totalShares = IBeefy(gem).balanceOf(address(this));
     if (totalShares > 0) {
-      try vault.redeem(totalShares, address(this), address(this)) {}
+      try IBeefy(gem).withdrawAll() {}
       catch (bytes memory reason) {
         emit RedeemFailed(reason);
       }
@@ -276,23 +352,42 @@ contract MorphoVaultPSM {
     emit RefundClaimed(msg.sender, amount);
   }
 
-  /// @notice Deposits idle USDC in the contract into the Morpho vault with correct bookkeeping
+  /// @notice Owner can force-settle a stale queued entry after SETTLEMENT_TIMEOUT
+  function forceSettle(
+    address _user
+  ) external onlyOwner {
+    if (!evacuated) revert NotEvacuated();
+    if (block.timestamp < evacuationTime + SETTLEMENT_TIMEOUT) revert SettlementTooEarly();
+    uint256 amount = scheduledWithdrawalAmount[_user];
+    if (amount == 0) revert NoWithdrawalScheduled();
+
+    uint256 toRefund = amount / (10 ** decimalDifference);
+
+    scheduledWithdrawalAmount[_user] = 0;
+    withdrawalEpoch[_user] = 0;
+    totalQueuedLiquidity -= toRefund;
+    totalStableLiquidity -= toRefund;
+    totalQueuedMAI -= amount;
+
+    // Send MAI directly to the user's address
+    IERC20(MAI_ADDRESS).transfer(_user, amount);
+    emit RefundClaimed(_user, amount);
+  }
+
+  /// @notice Deposits idle USDC in the contract into the Beefy vault with correct bookkeeping
   function sweep() external onlyOwner {
     if (evacuated) revert ContractIsPaused();
 
-    IERC20 iunder = IERC20(underlying);
-    uint256 balance = iunder.balanceOf(address(this));
+    uint256 balance = IERC20(underlying).balanceOf(address(this));
     if (balance == 0) revert InvalidAmount();
 
-    IFly(gem).deposit(balance, address(this));
+    IBeefy(gem).depositAll();
     totalStableLiquidity += balance;
 
     emit Swept(msg.sender, balance);
   }
 
   /// @notice Adds or removes a guardian address for emergency evacuation
-  /// @param _guardian The guardian address to add or remove
-  /// @param _enabled True to add, false to remove
   function setGuardian(
     address _guardian,
     bool _enabled
@@ -302,9 +397,6 @@ contract MorphoVaultPSM {
     emit GuardianUpdated(_guardian, _enabled);
   }
 
-  /// @notice Sets a function selector to paused or unpaused
-  /// @param _selector The function selector to pause or unpause
-  /// @param _paused Boolean indicating if the function should be paused (true) or unpaused (false)
   function setPaused(
     bytes4 _selector,
     bool _paused
@@ -313,8 +405,6 @@ contract MorphoVaultPSM {
     emit PauseEvent(msg.sender, _selector, _paused);
   }
 
-  /// @notice Transfers ownership of the contract to a new owner
-  /// @param _newOwner The address of the new owner
   function transferOwnership(
     address _newOwner
   ) external onlyOwner {
@@ -323,7 +413,6 @@ contract MorphoVaultPSM {
     emit OwnerUpdated(_newOwner);
   }
 
-  /// @notice Prepares the contract for an upgrade
   function setUpgrade() external onlyOwner {
     if (!stopped) {
       stopped = true;
@@ -331,20 +420,19 @@ contract MorphoVaultPSM {
     }
   }
 
-  /// @notice Allows the owner to transfer tokens from the contract
-  /// @param _token The address of the token to transfer
-  /// @param _to The address to transfer the tokens to
-  /// @param _amount The amount of tokens to transfer
   function transferToken(
     address _token,
     address _to,
     uint256 _amount
   ) external onlyOwner {
-    bool isProtectedToken = _token == gem || (_token == underlying && evacuated);
-    if (_token == MAI_ADDRESS && evacuated) {
-      uint256 available = IERC20(MAI_ADDRESS).balanceOf(address(this)) - totalQueuedMAI;
+    // MAI: reserve totalQueuedMAI
+    if (_token == MAI_ADDRESS) {
+      uint256 balance = IERC20(MAI_ADDRESS).balanceOf(address(this));
+      uint256 available = balance > totalQueuedMAI ? balance - totalQueuedMAI : 0;
       if (_amount > available) revert NotEnoughLiquidity();
     }
+    // underlying: NO reservation needed — users get MAI not USDC
+    bool isProtectedToken = _token == gem || (_token == underlying && evacuated);
     if (!isProtectedToken || (stopped && block.timestamp > upgradeTime)) {
       IERC20(_token).transfer(_to, _amount);
     } else {
@@ -352,24 +440,16 @@ contract MorphoVaultPSM {
     }
   }
 
-  /// @notice Allows the owner to withdraw MAI tokens from the contract
   function withdrawMAI() external onlyOwner {
     IERC20 _mai = IERC20(MAI_ADDRESS);
     uint256 balance = _mai.balanceOf(address(this));
 
-    if (evacuated) {
-      uint256 available = balance > totalQueuedMAI ? balance - totalQueuedMAI : 0;
-      if (available > 0) {
-        _mai.transfer(msg.sender, available);
-      }
-    } else {
-      _mai.transfer(msg.sender, balance);
+    uint256 available = balance > totalQueuedMAI ? balance - totalQueuedMAI : 0;
+    if (available > 0) {
+      _mai.transfer(msg.sender, available);
     }
   }
 
-  /// @notice Updates the minimum fees for deposit and withdrawal
-  /// @param _newMinimumDepositFee The new minimum deposit fee
-  /// @param _newMinimumWithdrawalFee The new minimum withdrawal fee
   function updateMinimumFees(
     uint256 _newMinimumDepositFee,
     uint256 _newMinimumWithdrawalFee
@@ -379,9 +459,6 @@ contract MorphoVaultPSM {
     emit MinimumFeesUpdated(_newMinimumDepositFee, _newMinimumWithdrawalFee);
   }
 
-  /// @notice Updates the deposit and withdrawal fees in basis points
-  /// @param _newDepositFee The new deposit fee in basis points
-  /// @param _newWithdrawalFee The new withdrawal fee in basis points
   function updateFeesBP(
     uint256 _newDepositFee,
     uint256 _newWithdrawalFee
@@ -391,9 +468,6 @@ contract MorphoVaultPSM {
     emit FeesUpdated(_newDepositFee, _newWithdrawalFee);
   }
 
-  /// @notice Updates the maximum deposit and withdrawal limits
-  /// @param _maxDeposit The new maximum deposit limit
-  /// @param _maxWithdraw The new maximum withdrawal limit
   function updateMax(
     uint256 _maxDeposit,
     uint256 _maxWithdraw

--- a/solidity/scripts/DeployBeefyGauntletFrontierBase.s.sol
+++ b/solidity/scripts/DeployBeefyGauntletFrontierBase.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/Script.sol';
+import '../contracts/BeefyVaultDDW.sol';
+
+contract DeployBeefyGauntletFrontierBase is Script {
+  function run() external {
+    vm.startBroadcast();
+
+    BeefyVaultPSM psm = new BeefyVaultPSM();
+    psm.initialize(
+      0x83152eE78d8f20Bba134A5FF000D551355Ce3996, // Beefy Gauntlet Frontier USDC (mooMorphoBaseGauntletFrontierUSDC)
+      0, // depositFee: 0 bps
+      30 // withdrawalFee: 30 bps / 0.3%
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/solidity/scripts/DeployBeefyGauntletMainnet.s.sol
+++ b/solidity/scripts/DeployBeefyGauntletMainnet.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/Script.sol';
+import '../contracts/BeefyVaultPSMMainnet.sol';
+
+contract DeployBeefyGauntletMainnet is Script {
+  function run() external {
+    vm.startBroadcast();
+
+    BeefyVaultPSMMainnet psm = new BeefyVaultPSMMainnet();
+    psm.initialize(
+      0x16F06dE7F077A95684DBAeEdD15A5808c3E13cD0, // Beefy Gauntlet Frontier mooToken
+      0, // depositFee: 0 bps (per QCI 250)
+      30, // withdrawalFee: 30 bps / 0.3% (per QCI 250)
+      0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6 // MAI on mainnet
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/solidity/scripts/DeployBeefyGauntletPrimeBase.s.sol
+++ b/solidity/scripts/DeployBeefyGauntletPrimeBase.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/Script.sol';
+import '../contracts/BeefyVaultDDW.sol';
+
+contract DeployBeefyGauntletPrimeBase is Script {
+  function run() external {
+    vm.startBroadcast();
+
+    BeefyVaultPSM psm = new BeefyVaultPSM();
+    psm.initialize(
+      0xCCB979379754d605FB4819A3e394D2e4087fC70e, // Beefy Gauntlet Prime USDC (mooMorphoBaseGauntletPrimeUSDC)
+      0, // depositFee: 0 bps
+      30 // withdrawalFee: 30 bps / 0.3%
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/solidity/scripts/DeployBeefySteakhouseBase.s.sol
+++ b/solidity/scripts/DeployBeefySteakhouseBase.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/Script.sol';
+import '../contracts/BeefyVaultDDW.sol';
+
+contract DeployBeefySteakhouseBase is Script {
+  function run() external {
+    vm.startBroadcast();
+
+    BeefyVaultPSM psm = new BeefyVaultPSM();
+    psm.initialize(
+      0xF1C55b6E063ee90A33FFE62deBe618962bae021e, // Beefy Steakhouse High Yield USDC (mooMorphoBaseSteakhouseHighYieldUSDC)
+      0, // depositFee: 0 bps
+      30 // withdrawalFee: 30 bps / 0.3%
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/solidity/scripts/DeployBeefySteakhouseMainnet.s.sol
+++ b/solidity/scripts/DeployBeefySteakhouseMainnet.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/Script.sol';
+import '../contracts/BeefyVaultPSMMainnet.sol';
+
+contract DeployBeefySteakhouseMainnet is Script {
+  function run() external {
+    vm.startBroadcast();
+
+    BeefyVaultPSMMainnet psm = new BeefyVaultPSMMainnet();
+    psm.initialize(
+      0x562Ea6FfFD1293b9433E7b81A2682C31892ea013, // Beefy Steakhouse Smokehouse mooToken
+      0, // depositFee: 0 bps (per QCI 250)
+      30, // withdrawalFee: 30 bps / 0.3% (per QCI 250)
+      0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6 // MAI on mainnet
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/solidity/scripts/DeployMorphoGauntlet.sol
+++ b/solidity/scripts/DeployMorphoGauntlet.sol
@@ -14,6 +14,10 @@ contract MyScript is Script {
       0xc0c5689e6f4D256E861F65465b691aeEcC0dEb12, 0, 30, 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE
     );
 
+    // TODO: After deploy, transfer ownership to multisig, then multisig calls:
+    // morphoVaultPSM.setGuardian(guardianAddress);
+    // morphoVaultPSM.transferOwnership(multisigAddress);
+
     vm.stopBroadcast();
   }
 }

--- a/solidity/scripts/DeployMorphoSteakhouse.sol
+++ b/solidity/scripts/DeployMorphoSteakhouse.sol
@@ -14,6 +14,10 @@ contract MyScript is Script {
       0xbeeF010f9cb27031ad51e3333f9aF9C6B1228183, 0, 30, 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE
     );
 
+    // TODO: After deploy, transfer ownership to multisig, then multisig calls:
+    // morphoVaultPSM.setGuardian(guardianAddress);
+    // morphoVaultPSM.transferOwnership(multisigAddress);
+
     vm.stopBroadcast();
   }
 }

--- a/solidity/test/echidna/EchidnaBeefyPSM.sol
+++ b/solidity/test/echidna/EchidnaBeefyPSM.sol
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {BeefyVaultPSM} from 'contracts/BeefyVaultDDW.sol';
+import {IERC20} from '../../interfaces/IERC20.sol';
+
+/// @title MockERC20Echidna
+/// @notice Minimal ERC20 for Echidna (no Foundry dependencies)
+contract MockERC20Echidna {
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    uint8 _decimals
+  ) {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+  }
+
+  function mint(
+    address to,
+    uint256 amount
+  ) external {
+    balanceOf[to] += amount;
+    totalSupply += amount;
+  }
+
+  function approve(
+    address spender,
+    uint256 amount
+  ) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+
+  function transfer(
+    address to,
+    uint256 amount
+  ) external returns (bool) {
+    require(balanceOf[msg.sender] >= amount, 'insufficient');
+    balanceOf[msg.sender] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 amount
+  ) external returns (bool) {
+    require(balanceOf[from] >= amount, 'insufficient');
+    require(allowance[from][msg.sender] >= amount, 'allowance');
+    allowance[from][msg.sender] -= amount;
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+}
+
+/// @title MockBeefyVault
+/// @notice Minimal IBeefy vault with 1:1 share ratio for deterministic testing
+contract MockBeefyVault {
+  MockERC20Echidna public underlying;
+  uint8 public decimals = 18;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+
+  constructor(
+    MockERC20Echidna _underlying
+  ) {
+    underlying = _underlying;
+  }
+
+  function want() external view returns (address) {
+    return address(underlying);
+  }
+
+  function balance() external view returns (uint256) {
+    return totalSupply;
+  }
+
+  function deposit(
+    uint256 amount
+  ) external {
+    underlying.transferFrom(msg.sender, address(this), amount);
+    balanceOf[msg.sender] += amount;
+    totalSupply += amount;
+  }
+
+  function depositAll() external {
+    uint256 amount = underlying.balanceOf(msg.sender);
+    if (amount == 0) return;
+    underlying.transferFrom(msg.sender, address(this), amount);
+    balanceOf[msg.sender] += amount;
+    totalSupply += amount;
+  }
+
+  function withdraw(
+    uint256 shares
+  ) external {
+    require(balanceOf[msg.sender] >= shares, 'insufficient shares');
+    balanceOf[msg.sender] -= shares;
+    totalSupply -= shares;
+    underlying.transfer(msg.sender, shares);
+  }
+
+  function withdrawAll() external {
+    uint256 shares = balanceOf[msg.sender];
+    if (shares == 0) return;
+    balanceOf[msg.sender] = 0;
+    totalSupply -= shares;
+    underlying.transfer(msg.sender, shares);
+  }
+
+  function getPricePerFullShare() external pure returns (uint256) {
+    return 1e18;
+  }
+}
+
+/// @title EchidnaBeefyPSM
+/// @notice Echidna property test harness for BeefyVaultPSM (Base version)
+/// @dev Uses hevm.etch to deploy mock MAI at the hardcoded MAI_ADDRESS,
+///      hevm.warp to advance time for withdrawal epochs,
+///      and hevm.prank to impersonate fuzz senders for multi-actor testing.
+contract EchidnaBeefyPSM {
+  // HEVM cheatcode interface (Echidna 2.x)
+  address internal constant HEVM = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+  // Hardcoded MAI address in BeefyVaultPSM (Base)
+  address internal constant MAI_BASE = 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE;
+
+  BeefyVaultPSM internal psm;
+  MockERC20Echidna internal usdc;
+  MockERC20Echidna internal mai;
+  MockBeefyVault internal vault;
+
+  // Privileged actors must be part of echidna.yaml's sender set so owner-only
+  // and guardian-only paths remain reachable during fuzzing.
+  address internal constant OWNER = address(0x20000);
+  address internal constant GUARDIAN = address(0x30000);
+
+  // Ghost variables for bookkeeping (public for post-run inspection)
+  uint256 public ghost_totalDeposited;
+  uint256 public ghost_totalScheduledMAI;
+  uint256 public ghost_totalWithdrawnMAI;
+  uint256 public ghost_totalRefundedMAI;
+  uint256 public ghost_totalSwept;
+  uint256 public ghost_depositCount;
+  uint256 public ghost_scheduleCount;
+  uint256 public ghost_withdrawCount;
+  uint256 public ghost_evacuateCount;
+  uint256 public ghost_refundCount;
+
+  constructor() {
+    usdc = new MockERC20Echidna('USDC', 'USDC', 6);
+
+    // Deploy mock MAI at a temp address to get runtime bytecode
+    MockERC20Echidna tempMai = new MockERC20Echidna('MAI', 'MAI', 18);
+
+    // Etch the mock's runtime code at the hardcoded MAI address
+    bytes memory maiCode = address(tempMai).code;
+    require(maiCode.length > 0, 'etch: empty code');
+    (bool etchOk,) = HEVM.call(abi.encodeWithSignature('etch(address,bytes)', MAI_BASE, maiCode));
+    require(etchOk, 'etch failed');
+
+    // Now the mock MAI is live at MAI_BASE
+    mai = MockERC20Echidna(MAI_BASE);
+
+    // Deploy mock Beefy vault and PSM
+    vault = new MockBeefyVault(usdc);
+    psm = new BeefyVaultPSM();
+    psm.initialize(address(vault), 0, 30); // 0% deposit, 30bps withdrawal
+    psm.setGuardian(GUARDIAN, true);
+    psm.transferOwnership(OWNER);
+    require(psm.guardians(GUARDIAN), 'guardian handoff failed');
+    require(psm.owner() == OWNER, 'owner handoff failed');
+
+    // Fund PSM with MAI for deposits (mint on the etched mock)
+    mai.mint(address(psm), 100_000_000 * 10 ** 18);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  HEVM helpers
+  // ═══════════════════════════════════════════════════════════
+
+  function _prank(
+    address actor
+  ) internal {
+    (bool ok,) = HEVM.call(abi.encodeWithSignature('prank(address)', actor));
+    require(ok, 'prank failed');
+  }
+
+  function _warp(
+    uint256 timestamp
+  ) internal {
+    (bool ok,) = HEVM.call(abi.encodeWithSignature('warp(uint256)', timestamp));
+    require(ok, 'warp failed');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Actions (called by Echidna fuzzer)
+  //  msg.sender = fuzz sender (e.g., 0x20000, 0x30000, 0x40000)
+  //  hevm.prank ensures PSM sees the fuzz sender, not the harness
+  // ═══════════════════════════════════════════════════════════
+
+  function deposit(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+    amount = _clamp(amount, 2 * 10 ** 6, 100_000 * 10 ** 6);
+
+    address actor = msg.sender;
+
+    // Mint USDC to actor and have actor approve PSM
+    usdc.mint(actor, amount);
+    _prank(actor);
+    usdc.approve(address(psm), amount);
+
+    // Actor deposits into PSM
+    _prank(actor);
+    try psm.deposit(amount) {
+      ghost_totalDeposited += amount;
+      ghost_depositCount++;
+    } catch {}
+  }
+
+  function scheduleWithdraw(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+
+    address actor = msg.sender;
+    if (psm.withdrawalEpoch(actor) != 0) return;
+
+    uint256 totalStable = psm.totalStableLiquidity();
+    uint256 totalQueued = psm.totalQueuedLiquidity();
+    if (totalStable <= totalQueued) return;
+
+    uint256 availableUsdc = totalStable - totalQueued;
+    uint256 availableMai = availableUsdc * 10 ** 12;
+    if (availableMai < 2 * 10 ** 18) return;
+
+    amount = _clamp(amount, 2 * 10 ** 18, availableMai);
+
+    // Mint MAI to actor and have actor approve PSM
+    mai.mint(actor, amount);
+    _prank(actor);
+    mai.approve(address(psm), amount);
+
+    // Actor schedules withdrawal
+    _prank(actor);
+    try psm.scheduleWithdraw(amount) {
+      ghost_totalScheduledMAI += amount;
+      ghost_scheduleCount++;
+    } catch {}
+  }
+
+  function withdraw() public {
+    address actor = msg.sender;
+    if (psm.withdrawalEpoch(actor) == 0) return;
+    if (psm.evacuated()) return; // withdraw blocked post-evacuation
+
+    // Warp past the 3-day withdrawal delay
+    uint256 epoch = psm.withdrawalEpoch(actor);
+    if (block.timestamp < epoch) {
+      _warp(epoch);
+    }
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+
+    _prank(actor);
+    try psm.withdraw() {
+      ghost_totalWithdrawnMAI += scheduled;
+      ghost_withdrawCount++;
+    } catch {}
+  }
+
+  function evacuateVault() public {
+    address actor = msg.sender;
+    if (actor != GUARDIAN && actor != OWNER) return;
+    if (psm.evacuated()) return;
+
+    _prank(actor);
+    try psm.evacuateVault() {
+      ghost_evacuateCount++;
+    } catch {}
+  }
+
+  function claimRefund() public {
+    if (!psm.evacuated()) return;
+
+    address actor = msg.sender;
+    if (psm.scheduledWithdrawalAmount(actor) == 0) return;
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+
+    _prank(actor);
+    try psm.claimRefund() {
+      ghost_totalRefundedMAI += scheduled;
+      ghost_refundCount++;
+    } catch {}
+  }
+
+  function forceSettle(
+    address target
+  ) public {
+    if (msg.sender != OWNER) return;
+    if (!psm.evacuated()) return;
+    if (block.timestamp < psm.evacuationTime() + psm.SETTLEMENT_TIMEOUT()) return;
+    if (psm.scheduledWithdrawalAmount(target) == 0) return;
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(target);
+
+    _prank(OWNER);
+    try psm.forceSettle(target) {
+      ghost_totalRefundedMAI += scheduled;
+      ghost_refundCount++;
+    } catch {}
+  }
+
+  function sweep(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+    if (msg.sender != OWNER) return;
+
+    amount = _clamp(amount, 1 * 10 ** 6, 50_000 * 10 ** 6);
+    usdc.mint(address(psm), amount);
+
+    _prank(OWNER);
+    try psm.sweep() {
+      ghost_totalSwept += amount;
+    } catch {}
+  }
+
+  function ownerWithdrawMAI() public {
+    if (msg.sender != OWNER) return;
+    _prank(OWNER);
+    try psm.withdrawMAI() {} catch {}
+  }
+
+  function ownerTransferMAI(
+    uint256 amount
+  ) public {
+    if (msg.sender != OWNER) return;
+
+    uint256 maiBalance = mai.balanceOf(address(psm));
+    if (maiBalance == 0) return;
+    amount = _clamp(amount, 1, maiBalance);
+
+    _prank(OWNER);
+    try psm.transferToken(address(mai), OWNER, amount) {} catch {}
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Properties (Echidna property mode)
+  // ═══════════════════════════════════════════════════════════
+
+  /// @notice PROPERTY 1: totalQueuedLiquidity <= totalStableLiquidity
+  function echidna_queued_never_exceeds_stable() public view returns (bool) {
+    return psm.totalStableLiquidity() >= psm.totalQueuedLiquidity();
+  }
+
+  /// @notice PROPERTY 2: vault backing + idle USDC >= totalStableLiquidity
+  function echidna_backing_sufficient() public view returns (bool) {
+    uint256 vaultBacking = vault.balanceOf(address(psm));
+    uint256 idleUsdc = usdc.balanceOf(address(psm));
+    return (vaultBacking + idleUsdc) >= psm.totalStableLiquidity();
+  }
+
+  /// @notice PROPERTY 3: post-evacuation, MAI balance >= totalQueuedMAI
+  function echidna_evacuated_mai_covers_refunds() public view returns (bool) {
+    if (!psm.evacuated()) return true;
+    if (psm.totalQueuedMAI() == 0) return true;
+    return mai.balanceOf(address(psm)) >= psm.totalQueuedMAI();
+  }
+
+  /// @notice PROPERTY 4: evacuation implies stopped
+  function echidna_evacuation_implies_stopped() public view returns (bool) {
+    if (psm.evacuated()) {
+      return psm.stopped();
+    }
+    return true;
+  }
+
+  /// @notice PROPERTY 5: totalQueuedMAI bounded (no underflow)
+  function echidna_totalQueuedMAI_bounded() public view returns (bool) {
+    return psm.totalQueuedMAI() <= 100_000_000 * 10 ** 18;
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Helpers
+  // ═══════════════════════════════════════════════════════════
+
+  function _clamp(
+    uint256 value,
+    uint256 low,
+    uint256 high
+  ) internal pure returns (uint256) {
+    if (value < low) return low;
+    if (value > high) return high;
+    return value;
+  }
+}

--- a/solidity/test/echidna/EchidnaBeefyPSMMainnet.sol
+++ b/solidity/test/echidna/EchidnaBeefyPSMMainnet.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {BeefyVaultPSMMainnet} from 'contracts/BeefyVaultPSMMainnet.sol';
+import {MockERC20Echidna, MockBeefyVault} from './EchidnaBeefyPSM.sol';
+
+/// @title EchidnaBeefyPSMMainnet
+/// @notice Echidna property test harness for BeefyVaultPSMMainnet (Ethereum version)
+/// @dev Uses hevm.prank for multi-actor testing and hevm.warp for time advancement.
+///      MAI_ADDRESS is configurable on mainnet, so no hevm.etch needed.
+contract EchidnaBeefyPSMMainnet {
+  // HEVM cheatcode interface (Echidna 2.x)
+  address internal constant HEVM = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
+  BeefyVaultPSMMainnet internal psm;
+  MockERC20Echidna internal usdc;
+  MockERC20Echidna internal mai;
+  MockBeefyVault internal vault;
+
+  // Privileged actors must be part of echidna.yaml's sender set so owner-only
+  // and guardian-only paths remain reachable during fuzzing.
+  address internal constant OWNER = address(0x20000);
+  address internal constant GUARDIAN = address(0x30000);
+
+  // Ghost variables (public for post-run inspection)
+  uint256 public ghost_totalDeposited;
+  uint256 public ghost_totalScheduledMAI;
+  uint256 public ghost_totalWithdrawnMAI;
+  uint256 public ghost_totalRefundedMAI;
+  uint256 public ghost_totalSwept;
+  uint256 public ghost_depositCount;
+  uint256 public ghost_scheduleCount;
+  uint256 public ghost_withdrawCount;
+  uint256 public ghost_evacuateCount;
+  uint256 public ghost_refundCount;
+
+  constructor() {
+    usdc = new MockERC20Echidna('USDC', 'USDC', 6);
+    mai = new MockERC20Echidna('MAI', 'MAI', 18);
+    vault = new MockBeefyVault(usdc);
+
+    psm = new BeefyVaultPSMMainnet();
+    psm.initialize(address(vault), 0, 30, address(mai));
+    psm.setGuardian(GUARDIAN, true);
+    psm.transferOwnership(OWNER);
+    require(psm.guardians(GUARDIAN), 'guardian handoff failed');
+    require(psm.owner() == OWNER, 'owner handoff failed');
+
+    // Fund PSM with MAI so deposits can succeed
+    mai.mint(address(psm), 100_000_000 * 10 ** 18);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  HEVM helpers
+  // ═══════════════════════════════════════════════════════════
+
+  function _prank(
+    address actor
+  ) internal {
+    (bool ok,) = HEVM.call(abi.encodeWithSignature('prank(address)', actor));
+    require(ok, 'prank failed');
+  }
+
+  function _warp(
+    uint256 timestamp
+  ) internal {
+    (bool ok,) = HEVM.call(abi.encodeWithSignature('warp(uint256)', timestamp));
+    require(ok, 'warp failed');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Actions (msg.sender = fuzz sender, hevm.prank for PSM calls)
+  // ═══════════════════════════════════════════════════════════
+
+  function deposit(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+    amount = _clamp(amount, 2 * 10 ** 6, 100_000 * 10 ** 6);
+
+    address actor = msg.sender;
+
+    usdc.mint(actor, amount);
+    _prank(actor);
+    usdc.approve(address(psm), amount);
+
+    _prank(actor);
+    try psm.deposit(amount) {
+      ghost_totalDeposited += amount;
+      ghost_depositCount++;
+    } catch {}
+  }
+
+  function scheduleWithdraw(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+
+    address actor = msg.sender;
+    if (psm.withdrawalEpoch(actor) != 0) return;
+
+    uint256 totalStable = psm.totalStableLiquidity();
+    uint256 totalQueued = psm.totalQueuedLiquidity();
+    if (totalStable <= totalQueued) return;
+
+    uint256 availableUsdc = totalStable - totalQueued;
+    uint256 availableMai = availableUsdc * 10 ** 12;
+    if (availableMai < 2 * 10 ** 18) return;
+
+    amount = _clamp(amount, 2 * 10 ** 18, availableMai);
+
+    mai.mint(actor, amount);
+    _prank(actor);
+    mai.approve(address(psm), amount);
+
+    _prank(actor);
+    try psm.scheduleWithdraw(amount) {
+      ghost_totalScheduledMAI += amount;
+      ghost_scheduleCount++;
+    } catch {}
+  }
+
+  function withdraw() public {
+    address actor = msg.sender;
+    if (psm.withdrawalEpoch(actor) == 0) return;
+    if (psm.evacuated()) return; // withdraw blocked post-evacuation
+
+    uint256 epoch = psm.withdrawalEpoch(actor);
+    if (block.timestamp < epoch) {
+      _warp(epoch);
+    }
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+
+    _prank(actor);
+    try psm.withdraw() {
+      ghost_totalWithdrawnMAI += scheduled;
+      ghost_withdrawCount++;
+    } catch {}
+  }
+
+  function evacuateVault() public {
+    address actor = msg.sender;
+    if (actor != GUARDIAN && actor != OWNER) return;
+    if (psm.evacuated()) return;
+
+    _prank(actor);
+    try psm.evacuateVault() {
+      ghost_evacuateCount++;
+    } catch {}
+  }
+
+  function claimRefund() public {
+    if (!psm.evacuated()) return;
+
+    address actor = msg.sender;
+    if (psm.scheduledWithdrawalAmount(actor) == 0) return;
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+
+    _prank(actor);
+    try psm.claimRefund() {
+      ghost_totalRefundedMAI += scheduled;
+      ghost_refundCount++;
+    } catch {}
+  }
+
+  function forceSettle(
+    address target
+  ) public {
+    if (msg.sender != OWNER) return;
+    if (!psm.evacuated()) return;
+    if (block.timestamp < psm.evacuationTime() + psm.SETTLEMENT_TIMEOUT()) return;
+    if (psm.scheduledWithdrawalAmount(target) == 0) return;
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(target);
+
+    _prank(OWNER);
+    try psm.forceSettle(target) {
+      ghost_totalRefundedMAI += scheduled;
+      ghost_refundCount++;
+    } catch {}
+  }
+
+  function sweep(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+    if (msg.sender != OWNER) return;
+
+    amount = _clamp(amount, 1 * 10 ** 6, 50_000 * 10 ** 6);
+    usdc.mint(address(psm), amount);
+
+    _prank(OWNER);
+    try psm.sweep() {
+      ghost_totalSwept += amount;
+    } catch {}
+  }
+
+  function ownerWithdrawMAI() public {
+    if (msg.sender != OWNER) return;
+    _prank(OWNER);
+    try psm.withdrawMAI() {} catch {}
+  }
+
+  function ownerTransferMAI(
+    uint256 amount
+  ) public {
+    if (msg.sender != OWNER) return;
+
+    uint256 maiBalance = mai.balanceOf(address(psm));
+    if (maiBalance == 0) return;
+    amount = _clamp(amount, 1, maiBalance);
+
+    _prank(OWNER);
+    try psm.transferToken(address(mai), OWNER, amount) {} catch {}
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Properties
+  // ═══════════════════════════════════════════════════════════
+
+  function echidna_queued_never_exceeds_stable() public view returns (bool) {
+    return psm.totalStableLiquidity() >= psm.totalQueuedLiquidity();
+  }
+
+  function echidna_backing_sufficient() public view returns (bool) {
+    uint256 vaultBacking = vault.balanceOf(address(psm));
+    uint256 idleUsdc = usdc.balanceOf(address(psm));
+    return (vaultBacking + idleUsdc) >= psm.totalStableLiquidity();
+  }
+
+  function echidna_evacuated_mai_covers_refunds() public view returns (bool) {
+    if (!psm.evacuated()) return true;
+    if (psm.totalQueuedMAI() == 0) return true;
+    return mai.balanceOf(address(psm)) >= psm.totalQueuedMAI();
+  }
+
+  function echidna_evacuation_implies_stopped() public view returns (bool) {
+    if (psm.evacuated()) {
+      return psm.stopped();
+    }
+    return true;
+  }
+
+  function echidna_totalQueuedMAI_bounded() public view returns (bool) {
+    return psm.totalQueuedMAI() <= 100_000_000 * 10 ** 18;
+  }
+
+  function echidna_available_survives_fees() public view returns (bool) {
+    uint256 available = psm.availableForWithdrawal();
+    if (available == 0) return true;
+    uint256 fee = psm.calculateFee(available, false);
+    return available > fee;
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Helpers
+  // ═══════════════════════════════════════════════════════════
+
+  function _clamp(
+    uint256 value,
+    uint256 low,
+    uint256 high
+  ) internal pure returns (uint256) {
+    if (value < low) return low;
+    if (value > high) return high;
+    return value;
+  }
+}

--- a/solidity/test/integration/BeefyIntegrationBase.sol
+++ b/solidity/test/integration/BeefyIntegrationBase.sol
@@ -21,7 +21,7 @@ contract BeefyIntegrationBase is Test {
   IBeefy internal _beefyVault;
   BeefyVaultPSM internal _psm;
 
-  function setUp() public {
+  function setUp() public virtual {
     vm.createSelectFork(vm.rpcUrl('base'), _FORK_BLOCK);
     vm.startPrank(_owner);
     deal(address(_usdbcToken), _owner, 100_000_000 * 10 ** 6);

--- a/solidity/test/integration/GauntletFrontierMainnet.t.sol
+++ b/solidity/test/integration/GauntletFrontierMainnet.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {BeefyVaultPSMMainnet} from 'contracts/BeefyVaultPSMMainnet.sol';
+import {MainnetIntegrationBase} from './MainnetIntegrationBase.sol';
+
+/// @title GauntletFrontierMainnet
+/// @notice Integration tests for Beefy Gauntlet Frontier vault PSM on Ethereum mainnet
+contract GauntletFrontierMainnet is MainnetIntegrationBase {
+  function _mooTokenAddress() internal pure override returns (address) {
+    return 0x16F06dE7F077A95684DBAeEdD15A5808c3E13cD0; // Moo Morpho Gauntlet Frontier USDC
+  }
+
+  function test_deposit_convertsUsdcToMai() public {
+    uint256 depositAmount = 1000 * 10 ** 6; // 1000 USDC
+    _usdcToken.approve(address(_psm), depositAmount);
+
+    uint256 maiBefore = _maiToken.balanceOf(_owner);
+    _psm.deposit(depositAmount);
+    uint256 maiAfter = _maiToken.balanceOf(_owner);
+
+    // With 1% fee (test base uses 100 bps), user gets 990 USDC worth of MAI
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 expectedMAI = (depositAmount - fee) * 10 ** 12;
+    assertEq(maiAfter - maiBefore, expectedMAI, 'MAI received should match deposit minus fee');
+  }
+
+  function test_scheduleWithdraw_locksForThreeDays() public {
+    // Deposit first
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Schedule withdrawal
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Verify epoch is set to 3 days from now
+    uint256 epoch = _psm.withdrawalEpoch(_owner);
+    assertEq(epoch, block.timestamp + 3 days, 'Withdrawal epoch should be 3 days from now');
+    assertEq(_psm.scheduledWithdrawalAmount(_owner), withdrawMAI, 'Scheduled amount should match');
+  }
+
+  function test_withdraw_afterEpoch_returnsUsdc() public {
+    // Deposit
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Schedule withdrawal
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Warp past 3-day delay
+    vm.warp(block.timestamp + 3 days + 1);
+
+    // Execute withdrawal
+    uint256 usdcBefore = _usdcToken.balanceOf(_owner);
+    _psm.withdraw();
+    uint256 usdcAfter = _usdcToken.balanceOf(_owner);
+
+    // User should receive USDC minus withdrawal fee
+    assertGt(usdcAfter, usdcBefore, 'User should have received USDC');
+  }
+
+  function test_withdraw_beforeEpoch_reverts() public {
+    // Deposit
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Schedule withdrawal
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Try to withdraw before epoch (only warp 1 day)
+    vm.warp(block.timestamp + 1 days);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.WithdrawalNotAvailable.selector);
+    _psm.withdraw();
+  }
+
+  function test_feeCalculation_minimumFeeApplied() public {
+    // With 100 bps (1%) withdrawal fee, $1 minimum kicks in below $100 withdrawal
+    // Withdraw 50 USDC worth: 1% of 50 = $0.50, but minimum is $1
+    uint256 amount = 50 * 10 ** 6;
+    uint256 fee = _psm.calculateFee(amount, false);
+    assertEq(fee, 1_000_000, 'Fee should be $1 minimum (1_000_000)');
+  }
+
+  function test_feeCalculation_percentageFeeApplied() public {
+    // Withdraw 500 USDC worth: 1% of 500 = $5, which is > $1 minimum
+    uint256 amount = 500 * 10 ** 6;
+    uint256 fee = _psm.calculateFee(amount, false);
+    uint256 expectedFee = 500 * 10 ** 6 * 100 / 10_000; // 1% = 5 USDC
+    assertEq(fee, expectedFee, 'Fee should be percentage-based');
+  }
+
+  function test_deposit_exceedsMaxDeposit_reverts() public {
+    // maxDeposit is 1e24, try to deposit more
+    uint256 tooMuch = 1e24 + 1;
+    _dealToken(address(_usdcToken), _owner, tooMuch);
+    vm.startPrank(_owner);
+    _usdcToken.approve(address(_psm), tooMuch);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmount.selector);
+    _psm.deposit(tooMuch);
+  }
+
+  function test_deposit_belowMinimumAmount_reverts() public {
+    // minimumDepositFee is 1_000_000 ($1), deposit must be > that
+    uint256 tooSmall = 1_000_000; // exactly $1, needs to be strictly greater
+    _usdcToken.approve(address(_psm), tooSmall);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmount.selector);
+    _psm.deposit(tooSmall);
+  }
+
+  function test_deposit_insufficientMaiBalance_reverts() public {
+    // Deploy a fresh PSM with no MAI funding
+    BeefyVaultPSMMainnet emptyPsm = new BeefyVaultPSMMainnet();
+    emptyPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(emptyPsm), depositAmount);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InsufficientMAIBalance.selector);
+    emptyPsm.deposit(depositAmount);
+  }
+}

--- a/solidity/test/integration/MainnetIntegrationBase.sol
+++ b/solidity/test/integration/MainnetIntegrationBase.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {Test} from 'forge-std/Test.sol';
+
+import {BeefyVaultPSMMainnet} from 'contracts/BeefyVaultPSMMainnet.sol';
+import {IBeefy} from '../../interfaces/IBeefy.sol';
+import {console} from 'forge-std/console.sol';
+
+/// @title MainnetIntegrationBase
+/// @notice Base contract for Ethereum Mainnet fork tests
+/// @dev Override _mooTokenAddress() to test with a different Beefy vault
+contract MainnetIntegrationBase is Test {
+  // Use latest block for public RPCs - set specific block for production testing
+  // uint256 internal constant _FORK_BLOCK = 21_350_000;
+
+  address internal _user = makeAddr('user');
+  address internal _owner = makeAddr('owner');
+
+  // Mainnet addresses
+  IERC20 internal _mooToken;
+  IERC20 internal _usdcToken = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48); // USDC
+  IERC20 internal _maiToken = IERC20(0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6); // MAI on mainnet
+
+  IBeefy internal _beefyVault;
+  BeefyVaultPSMMainnet internal _psm;
+
+  /// @notice Override to test with a different Beefy vault
+  function _mooTokenAddress() internal pure virtual returns (address) {
+    return 0x562Ea6FfFD1293b9433E7b81A2682C31892ea013; // Moo Morpho Smokehouse USDC (default)
+  }
+
+  // MAI whale address (owner with large balance)
+  address internal constant _MAI_WHALE = 0x3182E6856c3B59C39114416075770Ec9DC9Ff436;
+
+  /// @notice Helper to deal tokens by writing directly to storage or transferring from whale
+  /// @dev USDC uses slot 9 for balances, MAI uses whale transfer due to non-standard storage
+  /// @dev This function handles prank context - it stops any active prank, does the deal, and caller must restart prank if needed
+  function _dealToken(
+    address token,
+    address to,
+    uint256 amount
+  ) internal {
+    if (token == address(_maiToken)) {
+      // MAI has non-standard storage layout, transfer from whale instead
+      // Stop any active prank before starting a new one
+      vm.stopPrank();
+      vm.prank(_MAI_WHALE);
+      IERC20(token).transfer(to, amount);
+    } else {
+      // USDC uses slot 9 for balances (vm.store doesn't need prank context)
+      uint256 slot;
+      if (token == address(_usdcToken)) {
+        slot = 9; // USDC balance slot
+      } else {
+        slot = 0; // Standard ERC20 balance slot
+      }
+      bytes32 storageSlot = keccak256(abi.encode(to, slot));
+      vm.store(token, storageSlot, bytes32(amount));
+    }
+  }
+
+  function setUp() public virtual {
+    vm.createSelectFork(vm.rpcUrl('mainnet'));
+
+    _mooToken = IERC20(_mooTokenAddress());
+
+    // Deal USDC tokens for testing using direct storage writes (no prank needed)
+    _dealToken(address(_usdcToken), _owner, 100_000_000 * 10 ** 6);
+    _dealToken(address(_usdcToken), _user, 100_000_000 * 10 ** 6);
+
+    vm.startPrank(_owner);
+    _beefyVault = IBeefy(address(_mooToken));
+    _psm = new BeefyVaultPSMMainnet();
+    vm.stopPrank();
+
+    // Fund PSM with MAI for deposits (uses whale transfer, needs its own prank)
+    // Note: Whale has ~7M MAI, so we use 5M to leave some buffer
+    _dealToken(address(_maiToken), address(_psm), 5_000_000 * 10 ** 18);
+
+    vm.startPrank(_owner);
+    // Initialize with 1% deposit and withdrawal fees, mainnet MAI address
+    _psm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+    _psm.approveBeef();
+  }
+}

--- a/solidity/test/integration/MorphoEvacuateSweepIntegration.t.sol
+++ b/solidity/test/integration/MorphoEvacuateSweepIntegration.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Test} from 'forge-std/Test.sol';
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {MorphoVaultPSM} from 'contracts/MorphoVaultPSM.sol';
+import {IFly} from '../../interfaces/IFly.sol';
+
+/// @title MorphoEvacuateSweepIntegrationTest
+/// @notice Integration tests for evacuateVault and sweep against real Base Morpho vaults
+/// @dev Fork tests targeting both Gauntlet and Steakhouse vaults
+contract MorphoEvacuateSweepIntegrationTest is Test {
+  // Base chain addresses
+  address internal constant MORPHO_GAUNTLET = 0xc0c5689e6f4D256E861F65465b691aeEcC0dEb12;
+  address internal constant MORPHO_STEAKHOUSE = 0xbeeF010f9cb27031ad51e3333f9aF9C6B1228183;
+  address internal constant MAI_BASE = 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE;
+  address internal constant USDC_BASE = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+  MorphoVaultPSM internal psmGauntlet;
+  MorphoVaultPSM internal psmSteakhouse;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+  address internal user1 = makeAddr('user1');
+
+  IERC20 internal usdc = IERC20(USDC_BASE);
+  IERC20 internal mai = IERC20(MAI_BASE);
+
+  function _dealUSDC(
+    address to,
+    uint256 amount
+  ) internal {
+    bytes32 storageSlot = keccak256(abi.encode(to, uint256(9)));
+    vm.store(USDC_BASE, storageSlot, bytes32(amount));
+  }
+
+  function _dealMAI(
+    address to,
+    uint256 amount
+  ) internal {
+    deal(MAI_BASE, to, amount);
+  }
+
+  function _deployPSM(
+    address vault
+  ) internal returns (MorphoVaultPSM psm) {
+    vm.startPrank(owner);
+    psm = new MorphoVaultPSM();
+    psm.initialize(vault, 0, 30, MAI_BASE);
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+    _dealMAI(address(psm), 10_000_000 * 10 ** 18);
+  }
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('base'));
+    psmGauntlet = _deployPSM(MORPHO_GAUNTLET);
+    psmSteakhouse = _deployPSM(MORPHO_STEAKHOUSE);
+    _dealUSDC(user1, 1_000_000 * 10 ** 6);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Full migration flow test (Gauntlet)
+  // ═══════════════════════════════════════════════════════════
+
+  function test_fullMigrationFlow_Gauntlet() public {
+    MorphoVaultPSM oldPsm = psmGauntlet;
+    IFly vault = IFly(MORPHO_GAUNTLET);
+
+    // Step 1: User deposits into old PSM
+    vm.startPrank(user1);
+    usdc.approve(address(oldPsm), 100_000 * 10 ** 6);
+    oldPsm.deposit(100_000 * 10 ** 6);
+    vm.stopPrank();
+
+    uint256 oldStable = oldPsm.totalStableLiquidity();
+    assertGt(vault.balanceOf(address(oldPsm)), 0, 'Old PSM should have vault shares');
+
+    // Step 2: Guardian evacuates old PSM
+    vm.prank(guardian);
+    oldPsm.evacuateVault();
+
+    assertTrue(oldPsm.evacuated(), 'Old PSM should be evacuated');
+    assertEq(vault.balanceOf(address(oldPsm)), 0, 'Old PSM vault shares should be 0');
+    uint256 usdcInOldPsm = usdc.balanceOf(address(oldPsm));
+    assertGt(usdcInOldPsm, 0, 'Old PSM should hold USDC');
+
+    // Step 3: Wait 2 days for transferToken unlock
+    vm.warp(block.timestamp + 2 days + 1);
+
+    // Step 4: Transfer USDC out of old PSM to owner
+    vm.prank(owner);
+    oldPsm.transferToken(USDC_BASE, owner, usdcInOldPsm);
+    assertEq(usdc.balanceOf(address(oldPsm)), 0, 'Old PSM should have 0 USDC');
+
+    // Step 5: Deploy new PSM and send USDC to it
+    MorphoVaultPSM newPsm = _deployPSM(MORPHO_GAUNTLET);
+    vm.prank(owner);
+    usdc.transfer(address(newPsm), usdcInOldPsm);
+
+    // Step 6: Sweep USDC into new PSM's vault
+    vm.prank(owner);
+    newPsm.sweep();
+
+    // Verify: new PSM is operational with correct bookkeeping
+    assertEq(newPsm.totalStableLiquidity(), usdcInOldPsm, 'New PSM totalStableLiquidity matches');
+    assertGt(vault.balanceOf(address(newPsm)), 0, 'New PSM should have vault shares');
+    assertEq(usdc.balanceOf(address(newPsm)), 0, 'No idle USDC in new PSM');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Full migration flow test (Steakhouse)
+  // ═══════════════════════════════════════════════════════════
+
+  function test_fullMigrationFlow_Steakhouse() public {
+    MorphoVaultPSM oldPsm = psmSteakhouse;
+    IFly vault = IFly(MORPHO_STEAKHOUSE);
+
+    // Deposit
+    vm.startPrank(user1);
+    usdc.approve(address(oldPsm), 100_000 * 10 ** 6);
+    oldPsm.deposit(100_000 * 10 ** 6);
+    vm.stopPrank();
+
+    // Evacuate
+    vm.prank(guardian);
+    oldPsm.evacuateVault();
+
+    assertTrue(oldPsm.evacuated());
+    uint256 usdcInOldPsm = usdc.balanceOf(address(oldPsm));
+
+    // Wait + transfer
+    vm.warp(block.timestamp + 2 days + 1);
+    vm.prank(owner);
+    oldPsm.transferToken(USDC_BASE, owner, usdcInOldPsm);
+
+    // Deploy new + sweep
+    MorphoVaultPSM newPsm = _deployPSM(MORPHO_STEAKHOUSE);
+    vm.prank(owner);
+    usdc.transfer(address(newPsm), usdcInOldPsm);
+    vm.prank(owner);
+    newPsm.sweep();
+
+    assertEq(newPsm.totalStableLiquidity(), usdcInOldPsm);
+    assertGt(vault.balanceOf(address(newPsm)), 0);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Evacuation with yield accumulation
+  // ═══════════════════════════════════════════════════════════
+
+  function test_evacuateWithYield_Gauntlet() public {
+    IFly vault = IFly(MORPHO_GAUNTLET);
+
+    // Deposit
+    vm.startPrank(user1);
+    usdc.approve(address(psmGauntlet), 100_000 * 10 ** 6);
+    psmGauntlet.deposit(100_000 * 10 ** 6);
+    vm.stopPrank();
+
+    uint256 sharesAfterDeposit = vault.balanceOf(address(psmGauntlet));
+    uint256 stableLiquidity = psmGauntlet.totalStableLiquidity();
+
+    // Warp forward to accumulate yield
+    vm.warp(block.timestamp + 90 days);
+
+    // Vault should have more assets per share after yield
+    uint256 assetsNow = vault.convertToAssets(sharesAfterDeposit);
+    // Note: yield might be minimal in a fork test, but the flow should work
+
+    // Evacuate
+    vm.prank(guardian);
+    psmGauntlet.evacuateVault();
+
+    uint256 usdcRecovered = usdc.balanceOf(address(psmGauntlet));
+
+    // Recovered USDC should be >= totalStableLiquidity (includes yield)
+    assertGe(usdcRecovered, stableLiquidity, 'Should recover at least the deposited amount plus yield');
+    assertEq(psmGauntlet.totalStableLiquidity(), stableLiquidity, 'Bookkeeping unchanged');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Sweep against real vault
+  // ═══════════════════════════════════════════════════════════
+
+  function test_sweepAgainstRealVault_Gauntlet() public {
+    IFly vault = IFly(MORPHO_GAUNTLET);
+
+    // Send USDC directly (simulating migration transfer)
+    uint256 amount = 50_000 * 10 ** 6;
+    _dealUSDC(address(psmGauntlet), amount);
+
+    uint256 sharesBefore = vault.balanceOf(address(psmGauntlet));
+
+    vm.prank(owner);
+    psmGauntlet.sweep();
+
+    uint256 sharesAfter = vault.balanceOf(address(psmGauntlet));
+    assertGt(sharesAfter, sharesBefore, 'Vault shares should increase');
+    assertEq(psmGauntlet.totalStableLiquidity(), amount, 'totalStableLiquidity updated');
+    assertEq(usdc.balanceOf(address(psmGauntlet)), 0, 'No idle USDC after sweep');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Post-evacuation: new PSM accepts deposits after sweep
+  // ═══════════════════════════════════════════════════════════
+
+  function test_newPsmOperationalAfterSweep() public {
+    // Evacuate old
+    vm.startPrank(user1);
+    usdc.approve(address(psmGauntlet), 50_000 * 10 ** 6);
+    psmGauntlet.deposit(50_000 * 10 ** 6);
+    vm.stopPrank();
+
+    vm.prank(guardian);
+    psmGauntlet.evacuateVault();
+
+    vm.warp(block.timestamp + 2 days + 1);
+    uint256 usdcRecovered = usdc.balanceOf(address(psmGauntlet));
+    vm.prank(owner);
+    psmGauntlet.transferToken(USDC_BASE, owner, usdcRecovered);
+
+    // Deploy new PSM, sweep
+    MorphoVaultPSM newPsm = _deployPSM(MORPHO_GAUNTLET);
+    vm.prank(owner);
+    usdc.transfer(address(newPsm), usdcRecovered);
+    vm.prank(owner);
+    newPsm.sweep();
+
+    // New PSM should accept new user deposits
+    _dealUSDC(user1, 10_000 * 10 ** 6);
+    vm.startPrank(user1);
+    usdc.approve(address(newPsm), 10_000 * 10 ** 6);
+    newPsm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+
+    assertGt(newPsm.totalStableLiquidity(), usdcRecovered, 'New deposits add to swept liquidity');
+  }
+}

--- a/solidity/test/integration/SteakhouseMainnet.t.sol
+++ b/solidity/test/integration/SteakhouseMainnet.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {BeefyVaultPSMMainnet} from 'contracts/BeefyVaultPSMMainnet.sol';
+import {MainnetIntegrationBase} from './MainnetIntegrationBase.sol';
+
+/// @title SteakhouseMainnet
+/// @notice Integration tests for Beefy Steakhouse Smokehouse vault PSM on Ethereum mainnet
+contract SteakhouseMainnet is MainnetIntegrationBase {
+  // Uses default _mooTokenAddress() which returns Smokehouse: 0x562Ea6FfFD1293b9433E7b81A2682C31892ea013
+
+  function test_deposit_convertsUsdcToMai() public {
+    uint256 depositAmount = 1000 * 10 ** 6; // 1000 USDC
+    _usdcToken.approve(address(_psm), depositAmount);
+
+    uint256 maiBefore = _maiToken.balanceOf(_owner);
+    _psm.deposit(depositAmount);
+    uint256 maiAfter = _maiToken.balanceOf(_owner);
+
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 expectedMAI = (depositAmount - fee) * 10 ** 12;
+    assertEq(maiAfter - maiBefore, expectedMAI, 'MAI received should match deposit minus fee');
+  }
+
+  function test_scheduleWithdraw_locksForThreeDays() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    uint256 epoch = _psm.withdrawalEpoch(_owner);
+    assertEq(epoch, block.timestamp + 3 days, 'Withdrawal epoch should be 3 days from now');
+    assertEq(_psm.scheduledWithdrawalAmount(_owner), withdrawMAI, 'Scheduled amount should match');
+  }
+
+  function test_withdraw_afterEpoch_returnsUsdc() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    vm.warp(block.timestamp + 3 days + 1);
+
+    uint256 usdcBefore = _usdcToken.balanceOf(_owner);
+    _psm.withdraw();
+    uint256 usdcAfter = _usdcToken.balanceOf(_owner);
+
+    assertGt(usdcAfter, usdcBefore, 'User should have received USDC');
+  }
+
+  function test_withdraw_beforeEpoch_reverts() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 withdrawMAI = 100 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    vm.warp(block.timestamp + 1 days);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.WithdrawalNotAvailable.selector);
+    _psm.withdraw();
+  }
+
+  function test_feeCalculation_minimumFeeApplied() public {
+    uint256 amount = 50 * 10 ** 6;
+    uint256 fee = _psm.calculateFee(amount, false);
+    assertEq(fee, 1_000_000, 'Fee should be $1 minimum (1_000_000)');
+  }
+
+  function test_feeCalculation_percentageFeeApplied() public {
+    uint256 amount = 500 * 10 ** 6;
+    uint256 fee = _psm.calculateFee(amount, false);
+    uint256 expectedFee = 500 * 10 ** 6 * 100 / 10_000;
+    assertEq(fee, expectedFee, 'Fee should be percentage-based');
+  }
+
+  function test_deposit_exceedsMaxDeposit_reverts() public {
+    uint256 tooMuch = 1e24 + 1;
+    _dealToken(address(_usdcToken), _owner, tooMuch);
+    vm.startPrank(_owner);
+    _usdcToken.approve(address(_psm), tooMuch);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmount.selector);
+    _psm.deposit(tooMuch);
+  }
+
+  function test_deposit_belowMinimumAmount_reverts() public {
+    uint256 tooSmall = 1_000_000;
+    _usdcToken.approve(address(_psm), tooSmall);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmount.selector);
+    _psm.deposit(tooSmall);
+  }
+
+  function test_deposit_insufficientMaiBalance_reverts() public {
+    BeefyVaultPSMMainnet emptyPsm = new BeefyVaultPSMMainnet();
+    emptyPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(emptyPsm), depositAmount);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.InsufficientMAIBalance.selector);
+    emptyPsm.deposit(depositAmount);
+  }
+}

--- a/solidity/test/invariant/MorphoVaultPSMInvariant.sol
+++ b/solidity/test/invariant/MorphoVaultPSMInvariant.sol
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Test} from 'forge-std/Test.sol';
+import {StdInvariant} from 'forge-std/StdInvariant.sol';
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {MorphoVaultPSM} from 'contracts/MorphoVaultPSM.sol';
+import {IFly} from '../../interfaces/IFly.sol';
+import {console} from 'forge-std/console.sol';
+
+/// @title MockERC20
+/// @notice Minimal ERC20 for invariant testing without fork
+contract MockERC20 {
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    uint8 _decimals
+  ) {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+  }
+
+  function mint(
+    address to,
+    uint256 amount
+  ) external {
+    balanceOf[to] += amount;
+    totalSupply += amount;
+  }
+
+  function approve(
+    address spender,
+    uint256 amount
+  ) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+
+  function transfer(
+    address to,
+    uint256 amount
+  ) external returns (bool) {
+    require(balanceOf[msg.sender] >= amount, 'ERC20: insufficient balance');
+    balanceOf[msg.sender] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 amount
+  ) external returns (bool) {
+    require(balanceOf[from] >= amount, 'ERC20: insufficient balance');
+    require(allowance[from][msg.sender] >= amount, 'ERC20: insufficient allowance');
+    allowance[from][msg.sender] -= amount;
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    return true;
+  }
+}
+
+/// @title MockERC4626
+/// @notice Minimal ERC4626 vault with 1:1 share ratio for deterministic testing
+contract MockERC4626 {
+  MockERC20 public underlying;
+  string public name = 'Mock Vault';
+  string public symbol = 'mVault';
+  uint8 public decimals;
+
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor(
+    MockERC20 _underlying
+  ) {
+    underlying = _underlying;
+    decimals = _underlying.decimals();
+  }
+
+  function asset() external view returns (address) {
+    return address(underlying);
+  }
+
+  function convertToAssets(
+    uint256 shares
+  ) external pure returns (uint256) {
+    return shares; // 1:1 ratio for deterministic invariant testing
+  }
+
+  function convertToShares(
+    uint256 assets
+  ) external pure returns (uint256) {
+    return assets;
+  }
+
+  function deposit(
+    uint256 assets,
+    address receiver
+  ) external returns (uint256 shares) {
+    underlying.transferFrom(msg.sender, address(this), assets);
+    shares = assets; // 1:1
+    balanceOf[receiver] += shares;
+    totalSupply += shares;
+    return shares;
+  }
+
+  function withdraw(
+    uint256 assets,
+    address receiver,
+    address _owner
+  ) external returns (uint256 shares) {
+    shares = assets; // 1:1
+    require(balanceOf[_owner] >= shares, 'ERC4626: insufficient shares');
+    if (msg.sender != _owner) {
+      require(allowance[_owner][msg.sender] >= shares, 'ERC4626: insufficient allowance');
+      allowance[_owner][msg.sender] -= shares;
+    }
+    balanceOf[_owner] -= shares;
+    totalSupply -= shares;
+    underlying.transfer(receiver, assets);
+    return shares;
+  }
+
+  function redeem(
+    uint256 shares,
+    address receiver,
+    address _owner
+  ) external returns (uint256 assets) {
+    require(balanceOf[_owner] >= shares, 'ERC4626: insufficient shares');
+    if (msg.sender != _owner) {
+      require(allowance[_owner][msg.sender] >= shares, 'ERC4626: insufficient allowance');
+      allowance[_owner][msg.sender] -= shares;
+    }
+    assets = shares; // 1:1
+    balanceOf[_owner] -= shares;
+    totalSupply -= shares;
+    underlying.transfer(receiver, assets);
+    return assets;
+  }
+
+  function approve(
+    address spender,
+    uint256 amount
+  ) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+}
+
+/// @title MorphoPSMHandler
+/// @notice Handler for invariant testing — no fork needed
+contract MorphoPSMHandler is Test {
+  MorphoVaultPSM public psm;
+  MockERC20 public usdc;
+  MockERC20 public mai;
+  MockERC4626 public vault;
+
+  address public owner;
+  address public guardian;
+  address public guardian2;
+  address[] public actors;
+
+  // Ghost variables
+  uint256 public ghost_totalDeposited;
+  uint256 public ghost_totalWithdrawnExecuted;
+  uint256 public ghost_totalSwept;
+  uint256 public ghost_totalRefunded;
+  uint256 public ghost_depositCount;
+  uint256 public ghost_scheduleCount;
+  uint256 public ghost_withdrawCount;
+  uint256 public ghost_sweepCount;
+  uint256 public ghost_evacuateCount;
+  uint256 public ghost_refundCount;
+
+  constructor(
+    MorphoVaultPSM _psm,
+    MockERC20 _usdc,
+    MockERC20 _mai,
+    MockERC4626 _vault,
+    address _owner,
+    address _guardian
+  ) {
+    psm = _psm;
+    usdc = _usdc;
+    mai = _mai;
+    vault = _vault;
+    owner = _owner;
+    guardian = _guardian;
+    guardian2 = makeAddr('guardian2');
+
+    for (uint256 i = 0; i < 10; i++) {
+      actors.push(makeAddr(string(abi.encodePacked('actor', i))));
+    }
+  }
+
+  function deposit(
+    uint256 actorIndex,
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+
+    address actor = actors[actorIndex % actors.length];
+    amount = bound(amount, 1 * 10 ** 6, 100_000 * 10 ** 6);
+
+    usdc.mint(actor, amount);
+    vm.startPrank(actor);
+    usdc.approve(address(psm), amount);
+
+    try psm.deposit(amount) {
+      ghost_totalDeposited += amount;
+      ghost_depositCount++;
+    } catch {}
+    vm.stopPrank();
+  }
+
+  function scheduleWithdraw(
+    uint256 actorIndex,
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+
+    address actor = actors[actorIndex % actors.length];
+    if (psm.withdrawalEpoch(actor) != 0) return;
+
+    uint256 totalStable = psm.totalStableLiquidity();
+    uint256 totalQueued = psm.totalQueuedLiquidity();
+    if (totalStable <= totalQueued) return;
+
+    uint256 availableUsdc = totalStable - totalQueued;
+    uint256 availableMai = availableUsdc * 10 ** 12;
+    if (availableMai < psm.minimumWithdrawalFee()) return;
+
+    amount = bound(amount, psm.minimumWithdrawalFee(), availableMai);
+
+    mai.mint(actor, amount);
+    vm.startPrank(actor);
+    mai.approve(address(psm), amount);
+
+    try psm.scheduleWithdraw(amount) {
+      ghost_scheduleCount++;
+    } catch {}
+    vm.stopPrank();
+  }
+
+  function withdraw(
+    uint256 actorIndex
+  ) public {
+    if (psm.evacuated()) return;
+
+    address actor = actors[actorIndex % actors.length];
+    if (psm.withdrawalEpoch(actor) == 0) return;
+    if (block.timestamp < psm.withdrawalEpoch(actor)) {
+      vm.warp(psm.withdrawalEpoch(actor));
+    }
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+
+    vm.startPrank(actor);
+    try psm.withdraw() {
+      ghost_totalWithdrawnExecuted += scheduled / 10 ** 12;
+      ghost_withdrawCount++;
+    } catch {}
+    vm.stopPrank();
+  }
+
+  function evacuateVault(
+    uint256 _guardianSeed
+  ) public {
+    if (psm.evacuated()) return;
+
+    // Alternate between guardians to exercise multi-guardian access
+    address caller = _guardianSeed % 2 == 0 ? guardian : guardian2;
+    vm.prank(caller);
+    try psm.evacuateVault() {
+      ghost_evacuateCount++;
+      console.log('[handler] evacuateVault');
+    } catch {}
+  }
+
+  function claimRefund(
+    uint256 actorIndex
+  ) public {
+    if (!psm.evacuated()) return;
+
+    address actor = actors[actorIndex % actors.length];
+    if (psm.scheduledWithdrawalAmount(actor) == 0) return;
+
+    uint256 scheduled = psm.scheduledWithdrawalAmount(actor);
+    uint256 refundUsdc = scheduled / 10 ** 12;
+
+    vm.prank(actor);
+    try psm.claimRefund() {
+      ghost_totalRefunded += refundUsdc;
+      ghost_refundCount++;
+      console.log('[handler] claimRefund', refundUsdc);
+    } catch {}
+  }
+
+  function sweep(
+    uint256 amount
+  ) public {
+    if (psm.evacuated()) return;
+
+    amount = bound(amount, 1 * 10 ** 6, 50_000 * 10 ** 6);
+    usdc.mint(address(psm), amount);
+
+    vm.prank(owner);
+    try psm.sweep() {
+      ghost_totalSwept += amount;
+      ghost_sweepCount++;
+    } catch {}
+  }
+
+  function ownerWithdrawMAI() public {
+    if (!psm.evacuated()) return; // Only interesting post-evacuation
+
+    vm.prank(owner);
+    try psm.withdrawMAI() {} catch {}
+  }
+
+  function ownerTransferToken(
+    uint256 amount
+  ) public {
+    if (!psm.evacuated()) return;
+
+    // Try to transfer some MAI (tests the reserve protection)
+    uint256 maiBalance = mai.balanceOf(address(psm));
+    if (maiBalance == 0) return;
+    amount = bound(amount, 1, maiBalance);
+
+    vm.prank(owner);
+    try psm.transferToken(address(mai), owner, amount) {} catch {}
+  }
+
+  function warpTime(
+    uint256 secondsToWarp
+  ) public {
+    secondsToWarp = bound(secondsToWarp, 0, 7 days);
+    vm.warp(block.timestamp + secondsToWarp);
+  }
+}
+
+/// @title MorphoVaultPSMInvariantTest
+/// @notice All operations mixed — chaos scenario (no fork, uses mocks)
+contract MorphoVaultPSMInvariantTest is StdInvariant, Test {
+  MorphoVaultPSM internal psm;
+  MorphoPSMHandler internal handler;
+  MockERC20 internal usdc;
+  MockERC20 internal mai;
+  MockERC4626 internal vault;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+
+  function setUp() public {
+    // Deploy mocks
+    usdc = new MockERC20('USD Coin', 'USDC', 6);
+    mai = new MockERC20('MAI', 'MAI', 18);
+    vault = new MockERC4626(usdc);
+
+    // Deploy PSM
+    vm.startPrank(owner);
+    psm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    // Fund PSM with MAI
+    mai.mint(address(psm), 10_000_000 * 10 ** 18);
+
+    // Initialize
+    vm.startPrank(owner);
+    psm.initialize(address(vault), 0, 30, address(mai));
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+
+    // Setup handler
+    handler = new MorphoPSMHandler(psm, usdc, mai, vault, owner, guardian);
+
+    // Register handler's second guardian on PSM
+    address g2 = handler.guardian2();
+    vm.prank(owner);
+    psm.setGuardian(g2, true);
+
+    targetContract(address(handler));
+
+    bytes4[] memory selectors = new bytes4[](9);
+    selectors[0] = MorphoPSMHandler.deposit.selector;
+    selectors[1] = MorphoPSMHandler.scheduleWithdraw.selector;
+    selectors[2] = MorphoPSMHandler.withdraw.selector;
+    selectors[3] = MorphoPSMHandler.evacuateVault.selector;
+    selectors[4] = MorphoPSMHandler.claimRefund.selector;
+    selectors[5] = MorphoPSMHandler.sweep.selector;
+    selectors[6] = MorphoPSMHandler.warpTime.selector;
+    selectors[7] = MorphoPSMHandler.ownerWithdrawMAI.selector;
+    selectors[8] = MorphoPSMHandler.ownerTransferToken.selector;
+
+    targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+  }
+
+  /// @notice INVARIANT: totalStableLiquidity >= totalQueuedLiquidity always
+  function invariant_queuedNeverExceedsStable() public {
+    assertGe(
+      psm.totalStableLiquidity(),
+      psm.totalQueuedLiquidity(),
+      'INVARIANT VIOLATED: totalQueuedLiquidity exceeds totalStableLiquidity'
+    );
+  }
+
+  /// @notice INVARIANT: vault + idle USDC backing >= totalStableLiquidity
+  function invariant_backingSufficient() public {
+    uint256 vaultAssets = vault.convertToAssets(vault.balanceOf(address(psm)));
+    uint256 idleUsdc = usdc.balanceOf(address(psm));
+    uint256 totalBacking = vaultAssets + idleUsdc;
+
+    assertGe(totalBacking, psm.totalStableLiquidity(), 'INVARIANT VIOLATED: backing < totalStableLiquidity');
+  }
+
+  /// @notice INVARIANT: when evacuated, MAI balance covers queued refunds
+  function invariant_evacuatedMaiCoverage() public {
+    if (!psm.evacuated()) return;
+    if (psm.totalQueuedLiquidity() == 0) return;
+
+    uint256 maiBalance = mai.balanceOf(address(psm));
+    uint256 maiNeeded = psm.totalQueuedMAI();
+
+    assertGe(maiBalance, maiNeeded, 'INVARIANT VIOLATED: insufficient MAI for queued refunds');
+  }
+
+  /// @notice Summary stats
+  function invariant_callSummary() public view {
+    console.log('--- Morpho PSM Invariant Summary ---');
+    console.log('deposits:', handler.ghost_depositCount(), '| swept:', handler.ghost_sweepCount());
+    console.log('schedules:', handler.ghost_scheduleCount(), '| withdraws:', handler.ghost_withdrawCount());
+    console.log('evacuates:', handler.ghost_evacuateCount(), '| refunds:', handler.ghost_refundCount());
+    console.log('stable:', psm.totalStableLiquidity(), '| queued:', psm.totalQueuedLiquidity());
+    console.log('evacuated:', psm.evacuated() ? 1 : 0);
+  }
+}
+
+/// @title MorphoVaultPSMInvariantNormalOps
+/// @notice Normal operations + sweep only (no evacuation) — regression baseline
+contract MorphoVaultPSMInvariantNormalOps is StdInvariant, Test {
+  MorphoVaultPSM internal psm;
+  MorphoPSMHandler internal handler;
+  MockERC20 internal usdc;
+  MockERC20 internal mai;
+  MockERC4626 internal vault;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+
+  function setUp() public {
+    usdc = new MockERC20('USD Coin', 'USDC', 6);
+    mai = new MockERC20('MAI', 'MAI', 18);
+    vault = new MockERC4626(usdc);
+
+    vm.startPrank(owner);
+    psm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    mai.mint(address(psm), 10_000_000 * 10 ** 18);
+
+    vm.startPrank(owner);
+    psm.initialize(address(vault), 0, 30, address(mai));
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+
+    handler = new MorphoPSMHandler(psm, usdc, mai, vault, owner, guardian);
+
+    // Register handler's second guardian on PSM
+    address g2 = handler.guardian2();
+    vm.prank(owner);
+    psm.setGuardian(g2, true);
+
+    targetContract(address(handler));
+
+    bytes4[] memory selectors = new bytes4[](5);
+    selectors[0] = MorphoPSMHandler.deposit.selector;
+    selectors[1] = MorphoPSMHandler.scheduleWithdraw.selector;
+    selectors[2] = MorphoPSMHandler.withdraw.selector;
+    selectors[3] = MorphoPSMHandler.sweep.selector;
+    selectors[4] = MorphoPSMHandler.warpTime.selector;
+
+    targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+  }
+
+  function invariant_queuedNeverExceedsStable() public {
+    assertGe(psm.totalStableLiquidity(), psm.totalQueuedLiquidity(), 'queued exceeds stable');
+  }
+
+  function invariant_backingSufficient() public {
+    uint256 vaultAssets = vault.convertToAssets(vault.balanceOf(address(psm)));
+    uint256 idleUsdc = usdc.balanceOf(address(psm));
+
+    assertGe(vaultAssets + idleUsdc, psm.totalStableLiquidity(), 'backing < stable');
+  }
+}

--- a/solidity/test/unit/BeefyVaultEvacuateAndSweep.t.sol
+++ b/solidity/test/unit/BeefyVaultEvacuateAndSweep.t.sol
@@ -1,0 +1,770 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {Test} from 'forge-std/Test.sol';
+import {IBeefy} from '../../interfaces/IBeefy.sol';
+import {BeefyVaultPSM} from 'contracts/BeefyVaultDDW.sol';
+import {console} from 'forge-std/console.sol';
+import {BeefyIntegrationBase} from '../integration/BeefyIntegrationBase.sol';
+
+/// @title RevertingBeefyMock
+/// @notice IBeefy mock that reverts on withdrawAll — for testing evacuateVault failure path
+contract RevertingBeefyMock {
+  address public _want;
+  uint8 public _decimals = 18;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+
+  constructor(
+    address want_
+  ) {
+    _want = want_;
+  }
+
+  function want() external view returns (address) {
+    return _want;
+  }
+
+  function decimals() external view returns (uint8) {
+    return _decimals;
+  }
+
+  function balance() external view returns (uint256) {
+    return totalSupply;
+  }
+
+  function deposit(
+    uint256 amount
+  ) external {
+    IERC20(_want).transferFrom(msg.sender, address(this), amount);
+    balanceOf[msg.sender] += amount;
+    totalSupply += amount;
+  }
+
+  function depositAll() external {
+    uint256 amount = IERC20(_want).balanceOf(msg.sender);
+    IERC20(_want).transferFrom(msg.sender, address(this), amount);
+    balanceOf[msg.sender] += amount;
+    totalSupply += amount;
+  }
+
+  function withdraw(
+    uint256 shares
+  ) external {
+    balanceOf[msg.sender] -= shares;
+    totalSupply -= shares;
+    IERC20(_want).transfer(msg.sender, shares);
+  }
+
+  function withdrawAll() external pure {
+    revert('VAULT_COMPROMISED');
+  }
+
+  function getPricePerFullShare() external pure returns (uint256) {
+    return 1e18;
+  }
+
+  function approve(
+    address,
+    uint256
+  ) external pure returns (bool) {
+    return true;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+//  Base Beefy PSM Evacuate & Sweep Tests (fork-based)
+// ═══════════════════════════════════════════════════════════
+
+contract BeefyVaultPSMEvacuateAndSweepTest is BeefyIntegrationBase {
+  event VaultEvacuated(address indexed _caller, uint256 _sharesRedeemed);
+  event Swept(address indexed _caller, uint256 _amount);
+  event RefundClaimed(address indexed _user, uint256 _maiAmount);
+  event GuardianUpdated(address _guardian, bool _enabled);
+  event RedeemFailed(bytes _reason);
+
+  address internal guardian = makeAddr('guardian');
+  address internal random = makeAddr('random');
+
+  function setUp() public override {
+    super.setUp();
+
+    // Re-init with 0% deposit / 30bps withdrawal (matching production)
+    // Note: BeefyIntegrationBase already initializes with 100/100
+    // We work with the existing initialization
+
+    // Set up guardian
+    _psm.setGuardian(guardian, true);
+    vm.stopPrank();
+  }
+
+  function _depositAs(
+    address user,
+    uint256 amount
+  ) internal {
+    vm.startPrank(user);
+    _usdbcToken.approve(address(_psm), amount);
+    _psm.deposit(amount);
+    vm.stopPrank();
+  }
+
+  function _scheduleWithdrawAs(
+    address user,
+    uint256 maiAmount
+  ) internal {
+    vm.startPrank(user);
+    _maiToken.approve(address(_psm), maiAmount);
+    _psm.scheduleWithdraw(maiAmount);
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Guardian management
+  // ═══════════════════════════════════════════════════════════
+
+  function test_setGuardian_ownerCanAdd() public {
+    address newGuardian = makeAddr('newGuardian');
+    vm.prank(_owner);
+    _psm.setGuardian(newGuardian, true);
+    assertTrue(_psm.guardians(newGuardian));
+  }
+
+  function test_setGuardian_ownerCanRemove() public {
+    vm.prank(_owner);
+    _psm.setGuardian(guardian, false);
+    assertFalse(_psm.guardians(guardian));
+  }
+
+  function test_setGuardian_revertsForZeroAddress() public {
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.GuardianCannotBeZeroAddress.selector);
+    _psm.setGuardian(address(0), true);
+  }
+
+  function test_setGuardian_nonOwnerReverts() public {
+    vm.prank(random);
+    vm.expectRevert(BeefyVaultPSM.CallerIsNotOwner.selector);
+    _psm.setGuardian(random, true);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  evacuateVault tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_evacuateVault_happyPath() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    IBeefy beefy = IBeefy(address(_mooToken));
+    uint256 sharesBefore = beefy.balanceOf(address(_psm));
+    assertGt(sharesBefore, 0, 'PSM should have vault shares');
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    assertTrue(_psm.evacuated(), 'Should be evacuated');
+    assertTrue(_psm.stopped(), 'Should be stopped');
+    assertGt(_psm.upgradeTime(), block.timestamp, 'Upgrade time should be in future');
+    assertEq(beefy.balanceOf(address(_psm)), 0, 'Vault shares should be 0');
+    assertGt(_usdbcToken.balanceOf(address(_psm)), 0, 'PSM should hold USDC');
+  }
+
+  function test_evacuateVault_ownerCanCall() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(_owner);
+    _psm.evacuateVault();
+
+    assertTrue(_psm.evacuated());
+  }
+
+  function test_evacuateVault_guardianCanCall() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    assertTrue(_psm.evacuated());
+  }
+
+  function test_evacuateVault_randomAddressReverts() public {
+    vm.prank(random);
+    vm.expectRevert(BeefyVaultPSM.CallerIsNotGuardianOrOwner.selector);
+    _psm.evacuateVault();
+  }
+
+  function test_evacuateVault_emitsEvent() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+    IBeefy beefy = IBeefy(address(_mooToken));
+    uint256 sharesBefore = beefy.balanceOf(address(_psm));
+
+    vm.expectEmit(true, false, false, true);
+    emit VaultEvacuated(guardian, sharesBefore);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+  }
+
+  function test_evacuateVault_freezesDeposits() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    vm.startPrank(_user);
+    _usdbcToken.approve(address(_psm), 1000 * 10 ** 6);
+    vm.expectRevert(BeefyVaultPSM.ContractIsPaused.selector);
+    _psm.deposit(1000 * 10 ** 6);
+    vm.stopPrank();
+  }
+
+  function test_evacuateVault_freezesScheduleWithdraw() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    vm.startPrank(_user);
+    _maiToken.approve(address(_psm), 1000 * 10 ** 18);
+    vm.expectRevert(BeefyVaultPSM.ContractIsPaused.selector);
+    _psm.scheduleWithdraw(1000 * 10 ** 18);
+    vm.stopPrank();
+  }
+
+  function test_evacuateVault_idempotent() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Second call should succeed without reverting
+    vm.prank(_owner);
+    _psm.evacuateVault();
+
+    assertTrue(_psm.evacuated());
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  evacuateVault with reverting vault (try/catch)
+  // ═══════════════════════════════════════════════════════════
+
+  function test_evacuateVault_revertingVaultStillSetsEvacuated() public {
+    // Deploy a reverting mock
+    RevertingBeefyMock revertingVault = new RevertingBeefyMock(address(_usdbcToken));
+
+    // Deploy a fresh PSM with the reverting vault
+    vm.startPrank(_owner);
+    BeefyVaultPSM revertPsm = new BeefyVaultPSM();
+    deal(address(_maiToken), address(revertPsm), 10_000_000 * 10 ** 18);
+
+    // Need to make the mock return proper decimals
+    // The mock has decimals=18, underlying USDC=6, so decimalDifference=12 (correct)
+    revertPsm.initialize(address(revertingVault), 100, 100);
+
+    // Give the mock some balance to simulate shares
+    deal(address(_usdbcToken), _owner, 1000 * 10 ** 6);
+    _usdbcToken.approve(address(revertPsm), 1000 * 10 ** 6);
+    revertPsm.deposit(1000 * 10 ** 6);
+
+    // Now evacuate — withdrawAll() will revert, but evacuated should still be set
+    vm.expectEmit(false, false, false, false);
+    emit RedeemFailed('');
+
+    revertPsm.evacuateVault();
+
+    assertTrue(revertPsm.evacuated(), 'Should be evacuated even though vault reverted');
+    assertTrue(revertPsm.stopped(), 'Should be stopped');
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  claimRefund tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_claimRefund_happyPath() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    // User schedules withdrawal
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    assertEq(_psm.totalQueuedMAI(), withdrawMAI, 'totalQueuedMAI should track scheduled amount');
+
+    // Evacuate
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // User claims refund
+    uint256 maiBalBefore = _maiToken.balanceOf(_user);
+    vm.prank(_user);
+    _psm.claimRefund();
+
+    assertEq(_maiToken.balanceOf(_user), maiBalBefore + withdrawMAI, 'User should get MAI back');
+    assertEq(_psm.scheduledWithdrawalAmount(_user), 0, 'Scheduled amount should be cleared');
+    assertEq(_psm.withdrawalEpoch(_user), 0, 'Withdrawal epoch should be cleared');
+    assertEq(_psm.totalQueuedMAI(), 0, 'totalQueuedMAI should be 0');
+  }
+
+  function test_claimRefund_revertsWhenNotEvacuated() public {
+    vm.prank(_user);
+    vm.expectRevert(BeefyVaultPSM.NotEvacuated.selector);
+    _psm.claimRefund();
+  }
+
+  function test_claimRefund_revertsWhenNoScheduledWithdrawal() public {
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    vm.prank(_user);
+    vm.expectRevert(BeefyVaultPSM.NoWithdrawalScheduled.selector);
+    _psm.claimRefund();
+  }
+
+  function test_claimRefund_nonRoundAmount() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    // Use non-round amount to catch precision bugs
+    uint256 withdrawMAI = 40_000 * 10 ** 18 + 1;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    uint256 maiBalBefore = _maiToken.balanceOf(_user);
+    vm.prank(_user);
+    _psm.claimRefund();
+
+    assertEq(_maiToken.balanceOf(_user), maiBalBefore + withdrawMAI, 'Should refund exact MAI amount');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  sweep tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_sweep_happyPath() public {
+    // Send USDC directly to PSM (simulating migration)
+    uint256 sweepAmount = 50_000 * 10 ** 6;
+    deal(address(_usdbcToken), address(_psm), sweepAmount);
+
+    uint256 liquidityBefore = _psm.totalStableLiquidity();
+    IBeefy beefy = IBeefy(address(_mooToken));
+    uint256 sharesBefore = beefy.balanceOf(address(_psm));
+
+    vm.prank(_owner);
+    _psm.sweep();
+
+    assertEq(_psm.totalStableLiquidity(), liquidityBefore + sweepAmount, 'Liquidity should increase');
+    assertGt(beefy.balanceOf(address(_psm)), sharesBefore, 'Shares should increase');
+    assertEq(_usdbcToken.balanceOf(address(_psm)), 0, 'USDC should be deposited into vault');
+  }
+
+  function test_sweep_revertsWhenEvacuated() public {
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.ContractIsPaused.selector);
+    _psm.sweep();
+  }
+
+  function test_sweep_revertsWhenNoBalance() public {
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.InvalidAmount.selector);
+    _psm.sweep();
+  }
+
+  function test_sweep_nonOwnerReverts() public {
+    deal(address(_usdbcToken), address(_psm), 1000 * 10 ** 6);
+
+    vm.prank(random);
+    vm.expectRevert(BeefyVaultPSM.CallerIsNotOwner.selector);
+    _psm.sweep();
+  }
+
+  function test_sweep_emitsEvent() public {
+    uint256 sweepAmount = 10_000 * 10 ** 6;
+    deal(address(_usdbcToken), address(_psm), sweepAmount);
+
+    vm.expectEmit(true, false, false, true);
+    emit Swept(_owner, sweepAmount);
+
+    vm.prank(_owner);
+    _psm.sweep();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  withdrawMAI post-evacuation protection
+  // ═══════════════════════════════════════════════════════════
+
+  function test_withdrawMAI_protectsRefundsPostEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Owner tries to withdraw MAI — should only get excess above totalQueuedMAI
+    uint256 psmMaiBefore = _maiToken.balanceOf(address(_psm));
+    uint256 ownerMaiBefore = _maiToken.balanceOf(_owner);
+
+    vm.prank(_owner);
+    _psm.withdrawMAI();
+
+    uint256 ownerMaiAfter = _maiToken.balanceOf(_owner);
+    uint256 expectedAvailable = psmMaiBefore > withdrawMAI ? psmMaiBefore - withdrawMAI : 0;
+    assertEq(ownerMaiAfter - ownerMaiBefore, expectedAvailable, 'Owner should only get non-queued MAI');
+
+    // User can still claim refund
+    uint256 userMaiBefore = _maiToken.balanceOf(_user);
+    vm.prank(_user);
+    _psm.claimRefund();
+    assertEq(_maiToken.balanceOf(_user), userMaiBefore + withdrawMAI, 'User should still get full refund');
+  }
+
+  function test_withdrawMAI_transfersAllExcessPreEvacuationWhenNothingQueued() public {
+    uint256 maiBalance = _maiToken.balanceOf(address(_psm));
+
+    uint256 ownerBefore = _maiToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.withdrawMAI();
+
+    assertEq(
+      _maiToken.balanceOf(_owner), ownerBefore + maiBalance, 'Owner should get all excess MAI when nothing is queued'
+    );
+    assertEq(_maiToken.balanceOf(address(_psm)), 0, 'PSM should have no MAI left when nothing is queued');
+  }
+
+  function test_withdrawMAI_protectsQueuedMAIPreEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    uint256 psmMaiBefore = _maiToken.balanceOf(address(_psm));
+    uint256 ownerBefore = _maiToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.withdrawMAI();
+
+    assertEq(_maiToken.balanceOf(address(_psm)), withdrawMAI, 'PSM should retain queued MAI pre-evacuation');
+    assertEq(
+      _maiToken.balanceOf(_owner) - ownerBefore,
+      psmMaiBefore - withdrawMAI,
+      'Owner should only receive MAI in excess of the queued reserve'
+    );
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    uint256 userMaiBefore = _maiToken.balanceOf(_user);
+    vm.prank(_user);
+    _psm.claimRefund();
+
+    assertEq(
+      _maiToken.balanceOf(_user), userMaiBefore + withdrawMAI, 'User should still be able to claim the full refund'
+    );
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  transferToken post-evacuation protection
+  // ═══════════════════════════════════════════════════════════
+
+  function test_transferToken_blocksUnderlyingPostEvacuation() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    uint256 usdcInPsm = _usdbcToken.balanceOf(address(_psm));
+    assertGt(usdcInPsm, 0, 'PSM should hold USDC post-evacuation');
+
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.UpgradeNotScheduled.selector);
+    _psm.transferToken(address(_usdbcToken), _owner, usdcInPsm);
+  }
+
+  function test_transferToken_allowsUnderlyingAfterUpgradeTime() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Warp past upgrade time
+    vm.warp(_psm.upgradeTime() + 1);
+
+    uint256 usdcInPsm = _usdbcToken.balanceOf(address(_psm));
+    uint256 ownerBefore = _usdbcToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.transferToken(address(_usdbcToken), _owner, usdcInPsm);
+
+    assertEq(_usdbcToken.balanceOf(_owner) - ownerBefore, usdcInPsm, 'Owner should receive USDC after upgrade time');
+  }
+
+  function test_transferToken_limitsMAIPostEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Trying to transfer more MAI than available (above totalQueuedMAI) should revert
+    uint256 psmMaiBalance = _maiToken.balanceOf(address(_psm));
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.NotEnoughLiquidity.selector);
+    _psm.transferToken(address(_maiToken), _owner, psmMaiBalance);
+  }
+
+  function test_transferToken_protectsQueuedMAIPreEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    uint256 psmMaiBalance = _maiToken.balanceOf(address(_psm));
+    uint256 available = psmMaiBalance - withdrawMAI;
+
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.NotEnoughLiquidity.selector);
+    _psm.transferToken(address(_maiToken), _owner, psmMaiBalance);
+
+    uint256 ownerBefore = _maiToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.transferToken(address(_maiToken), _owner, available);
+
+    assertEq(_maiToken.balanceOf(_owner) - ownerBefore, available, 'Owner should only receive non-queued MAI');
+    assertEq(_maiToken.balanceOf(address(_psm)), withdrawMAI, 'Queued MAI must remain in the PSM');
+  }
+
+  function test_preEvacuationQueuedMAIDrainAttemptStillAllowsRefundAfterEvacuation() public {
+    uint256 sweepAmount = 50_000 * 10 ** 6;
+    deal(address(_usdbcToken), address(_psm), sweepAmount);
+
+    vm.prank(_owner);
+    _psm.sweep();
+
+    uint256 withdrawMAI = 10_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    vm.prank(_owner);
+    _psm.withdrawMAI();
+
+    assertEq(
+      _maiToken.balanceOf(address(_psm)), withdrawMAI, 'Pre-evacuation drain attempt must leave queued MAI intact'
+    );
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    uint256 userMaiBefore = _maiToken.balanceOf(_user);
+    vm.prank(_user);
+    _psm.claimRefund();
+
+    assertEq(_maiToken.balanceOf(_user), userMaiBefore + withdrawMAI, 'Refund should still succeed after evacuation');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  claimFees post-evacuation guard
+  // ═══════════════════════════════════════════════════════════
+
+  function test_claimFees_noOpPostEvacuation() public {
+    _depositAs(_user, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    uint256 ownerUsdcBefore = _usdbcToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.claimFees(); // Should return without doing anything
+
+    assertEq(_usdbcToken.balanceOf(_owner), ownerUsdcBefore, 'claimFees should be no-op post-evacuation');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  totalQueuedMAI bookkeeping
+  // ═══════════════════════════════════════════════════════════
+
+  function test_totalQueuedMAI_trackedOnSchedule() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    assertEq(_psm.totalQueuedMAI(), withdrawMAI);
+  }
+
+  function test_totalQueuedMAI_decrementedOnWithdraw() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    assertEq(_psm.totalQueuedMAI(), withdrawMAI);
+
+    // Warp past epoch and withdraw
+    vm.warp(block.timestamp + 4 days);
+    vm.prank(_user);
+    _psm.withdraw();
+
+    assertEq(_psm.totalQueuedMAI(), 0, 'totalQueuedMAI should be 0 after withdrawal');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Dust withdrawal rejection
+  // ═══════════════════════════════════════════════════════════
+
+  function test_scheduleWithdraw_rejectsDustAmount() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    // Amount that truncates to 0 USDC after division by 1e12
+    uint256 dustMAI = 2;
+    deal(address(_maiToken), _user, dustMAI);
+
+    vm.startPrank(_user);
+    _maiToken.approve(address(_psm), dustMAI);
+    vm.expectRevert(BeefyVaultPSM.InvalidAmountAfterFee.selector);
+    _psm.scheduleWithdraw(dustMAI);
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  withdraw blocked post-evacuation
+  // ═══════════════════════════════════════════════════════════
+
+  function test_withdraw_blockedPostEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    // Warp past 3-day epoch
+    vm.warp(block.timestamp + 3 days);
+
+    // Evacuate
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // withdraw() should be blocked by pausable modifier post-evacuation
+    vm.prank(_user);
+    vm.expectRevert(BeefyVaultPSM.ContractIsPaused.selector);
+    _psm.withdraw();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  forceSettle tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_forceSettle_happyPath() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    // Evacuate
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Warp past 30-day settlement timeout
+    vm.warp(block.timestamp + 30 days);
+
+    uint256 userMaiBefore = _maiToken.balanceOf(_user);
+    vm.prank(_owner);
+    _psm.forceSettle(_user);
+
+    assertEq(_maiToken.balanceOf(_user), userMaiBefore + withdrawMAI, 'User should receive MAI via forceSettle');
+    assertEq(_psm.scheduledWithdrawalAmount(_user), 0, 'Scheduled amount should be cleared');
+    assertEq(_psm.withdrawalEpoch(_user), 0, 'Withdrawal epoch should be cleared');
+  }
+
+  function test_forceSettle_revertsBeforeTimeout() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    // Evacuate
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Try forceSettle immediately — should revert
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.SettlementTooEarly.selector);
+    _psm.forceSettle(_user);
+  }
+
+  function test_forceSettle_revertsWhenNotEvacuated() public {
+    vm.prank(_owner);
+    vm.expectRevert(BeefyVaultPSM.NotEvacuated.selector);
+    _psm.forceSettle(_user);
+  }
+
+  function test_forceSettle_clearsQueue() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    uint256 queuedLiqBefore = _psm.totalQueuedLiquidity();
+    uint256 queuedMaiBefore = _psm.totalQueuedMAI();
+    assertGt(queuedLiqBefore, 0, 'Should have queued liquidity');
+    assertGt(queuedMaiBefore, 0, 'Should have queued MAI');
+
+    // Evacuate
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Warp past 30-day settlement timeout
+    vm.warp(block.timestamp + 30 days);
+
+    vm.prank(_owner);
+    _psm.forceSettle(_user);
+
+    assertEq(_psm.totalQueuedLiquidity(), 0, 'totalQueuedLiquidity should be 0 after forceSettle');
+    assertEq(_psm.totalQueuedMAI(), 0, 'totalQueuedMAI should be 0 after forceSettle');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  transferToken — owner gets ALL USDC after evacuation
+  // ═══════════════════════════════════════════════════════════
+
+  function test_transferToken_ownerGetsAllUsdcAfterEvacuation() public {
+    _depositAs(_user, 100_000 * 10 ** 6);
+
+    uint256 withdrawMAI = 40_000 * 10 ** 18;
+    deal(address(_maiToken), _user, withdrawMAI);
+    _scheduleWithdrawAs(_user, withdrawMAI);
+
+    // Evacuate — all vault shares redeemed to USDC
+    vm.prank(guardian);
+    _psm.evacuateVault();
+
+    // Warp past upgradeTime
+    vm.warp(_psm.upgradeTime() + 1);
+
+    uint256 usdcInPsm = _usdbcToken.balanceOf(address(_psm));
+    assertGt(usdcInPsm, 0, 'PSM should hold USDC post-evacuation');
+
+    // Owner should be able to transfer ALL USDC — no reservation needed
+    uint256 ownerBefore = _usdbcToken.balanceOf(_owner);
+    vm.prank(_owner);
+    _psm.transferToken(address(_usdbcToken), _owner, usdcInPsm);
+
+    assertEq(_usdbcToken.balanceOf(_owner) - ownerBefore, usdcInPsm, 'Owner should receive ALL USDC (no reservation)');
+    assertEq(_usdbcToken.balanceOf(address(_psm)), 0, 'PSM should have no USDC left');
+  }
+}

--- a/solidity/test/unit/BeefyVaultMainnet.sol
+++ b/solidity/test/unit/BeefyVaultMainnet.sol
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {Test} from 'forge-std/Test.sol';
+import {IBeefy} from '../../interfaces/IBeefy.sol';
+import {BeefyVaultPSMMainnet} from '../../contracts/BeefyVaultPSMMainnet.sol';
+import 'forge-std/console.sol';
+import {MainnetIntegrationBase} from '../integration/MainnetIntegrationBase.sol';
+import {StdCheats} from 'forge-std/StdCheats.sol';
+
+contract PsmMainnetConstructor is MainnetIntegrationBase {
+  function test_OwnerSet() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    assertEq(newPsm.owner(), address(_owner));
+  }
+
+  function test_TokenSet() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    assertEq(address(newPsm.gem()), address(_mooToken));
+  }
+
+  function test_MAIAddressSet() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    assertEq(newPsm.MAI_ADDRESS(), address(_maiToken));
+  }
+
+  function test_MAIAddressCannotBeZero() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+
+    vm.expectRevert(BeefyVaultPSMMainnet.MAIAddressCannotBeZero.selector);
+    newPsm.initialize(address(_mooToken), 100, 100, address(0));
+  }
+
+  function test_UnderlyingSet() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+    assertEq(address(newPsm.underlying()), address(_usdcToken));
+  }
+
+  function test_MinimumReservesDefaultsToZero() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    assertEq(newPsm.minimumReserves(), 0);
+  }
+
+  function test_Initialized() public {
+    BeefyVaultPSMMainnet newPsm = new BeefyVaultPSMMainnet();
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+
+    assertEq(newPsm.initialized(), true);
+    vm.expectRevert(BeefyVaultPSMMainnet.AlreadyInitialized.selector);
+    newPsm.initialize(address(_mooToken), 100, 100, address(_maiToken));
+  }
+}
+
+contract PsmMainnetMinimumReservesConfig is MainnetIntegrationBase {
+  event MinimumReservesUpdated(uint256 _oldMinimumReserves, uint256 _newMinimumReserves);
+
+  function test_SetMinimumReservesOnlyOwner() public {
+    vm.stopPrank();
+    vm.startPrank(_user);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.CallerIsNotOwner.selector);
+    _psm.setMinimumReserves(1000 * 10 ** 6);
+  }
+
+  function test_SetMinimumReservesEmitsEvent() public {
+    vm.expectEmit(true, true, true, true);
+    emit MinimumReservesUpdated(0, 1000 * 10 ** 6);
+
+    _psm.setMinimumReserves(1000 * 10 ** 6);
+  }
+
+  function test_SetMinimumReservesToZero() public {
+    _psm.setMinimumReserves(1000 * 10 ** 6);
+    assertEq(_psm.minimumReserves(), 1000 * 10 ** 6);
+
+    _psm.setMinimumReserves(0);
+    assertEq(_psm.minimumReserves(), 0);
+  }
+
+  function test_SetMinimumReservesUpdatesValue() public {
+    _psm.setMinimumReserves(500 * 10 ** 6);
+    assertEq(_psm.minimumReserves(), 500 * 10 ** 6);
+
+    _psm.setMinimumReserves(1000 * 10 ** 6);
+    assertEq(_psm.minimumReserves(), 1000 * 10 ** 6);
+  }
+
+  function testFuzz_SetMinimumReserves(
+    uint256 _amount
+  ) public {
+    _amount = bound(_amount, 0, 1_000_000_000 * 10 ** 6);
+
+    _psm.setMinimumReserves(_amount);
+    assertEq(_psm.minimumReserves(), _amount);
+  }
+}
+
+contract PsmMainnetMinimumReservesEnforcement is MainnetIntegrationBase {
+  function test_WithdrawBlockedByMinimumReserves() public {
+    // Deposit 1000 USDC
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Set minimum reserves to 900 USDC
+    _psm.setMinimumReserves(900 * 10 ** 6);
+
+    // Calculate available: totalLiquidity (~990 after 1% fee) - 900 = ~90 USDC
+    // Try to withdraw 100 USDC worth of MAI (more than available)
+    uint256 tooMuchMAI = 100 * 10 ** 18;
+
+    _maiToken.approve(address(_psm), tooMuchMAI);
+    vm.expectRevert(BeefyVaultPSMMainnet.MinimumReservesBreached.selector);
+    _psm.scheduleWithdraw(tooMuchMAI);
+  }
+
+  function test_WithdrawAllowedUpToAvailable() public {
+    // Deposit 1000 USDC
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Set minimum reserves to 500 USDC
+    _psm.setMinimumReserves(500 * 10 ** 6);
+
+    // Calculate available
+    uint256 available = _psm.availableForWithdrawal();
+    console.log('Available for withdrawal:', available);
+
+    // Withdraw exactly the available amount
+    uint256 withdrawAmountMAI = available * 10 ** 12;
+
+    _maiToken.approve(address(_psm), withdrawAmountMAI);
+    _psm.scheduleWithdraw(withdrawAmountMAI); // Should succeed
+
+    assertEq(_psm.scheduledWithdrawalAmount(_owner), withdrawAmountMAI);
+  }
+
+  function test_DepositUnaffectedByMinimumReserves() public {
+    // Set high minimum reserves before any deposits
+    _psm.setMinimumReserves(1_000_000 * 10 ** 6); // 1M USDC
+
+    // Deposits should still work
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+
+    uint256 maiBefore = _maiToken.balanceOf(_owner);
+    _psm.deposit(depositAmount);
+    uint256 maiAfter = _maiToken.balanceOf(_owner);
+
+    assertGt(maiAfter, maiBefore, 'User should have received MAI');
+  }
+
+  function test_ClaimFeesUnaffectedByMinimumReserves() public {
+    // Deposit and generate some fees
+    uint256 depositAmount = 10_000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Set high minimum reserves
+    _psm.setMinimumReserves(1_000_000 * 10 ** 6);
+
+    // claimFees should still work even with high minimum reserves
+    // The key test is that claimFees doesn't revert due to minimum reserves
+    uint256 balanceBefore = _usdcToken.balanceOf(_owner);
+    _psm.claimFees();
+    uint256 balanceAfter = _usdcToken.balanceOf(_owner);
+
+    // Fees may or may not have been claimed depending on yield accumulation
+    // The important thing is it doesn't revert
+    console.log('Fees claimed:', balanceAfter - balanceBefore);
+  }
+
+  function test_QueuedWithdrawalsAccountedCorrectly() public {
+    // Deposit 2000 USDC
+    uint256 depositAmount = 2000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Set minimum reserves to 500 USDC
+    _psm.setMinimumReserves(500 * 10 ** 6);
+
+    // First withdrawal of 1000 MAI (1000 USDC equivalent)
+    uint256 firstWithdrawMAI = 1000 * 10 ** 18;
+    _maiToken.approve(address(_psm), firstWithdrawMAI);
+    _psm.scheduleWithdraw(firstWithdrawMAI);
+
+    // Check available has decreased
+    uint256 availableAfterFirst = _psm.availableForWithdrawal();
+    console.log('Available after first schedule:', availableAfterFirst);
+
+    // totalLiquidity (~1980 after fee) - queued (1000) - min (500) = ~480 USDC
+    assertApproxEqAbs(availableAfterFirst, 480 * 10 ** 6, 30 * 10 ** 6, 'Available should be ~480 USDC');
+
+    // Second user tries to withdraw too much
+    vm.stopPrank();
+    vm.startPrank(_user);
+    _dealToken(address(_maiToken), _user, 600 * 10 ** 18);
+    _maiToken.approve(address(_psm), 600 * 10 ** 18);
+
+    vm.expectRevert(BeefyVaultPSMMainnet.MinimumReservesBreached.selector);
+    _psm.scheduleWithdraw(600 * 10 ** 18);
+  }
+
+  function test_ScheduledWithdrawalsCompleteEvenAfterReservesIncrease() public {
+    // Deposit 2000 USDC
+    uint256 depositAmount = 2000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Schedule withdrawal before setting minimum reserves
+    uint256 withdrawMAI = 1000 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Now increase minimum reserves to a very high value
+    _psm.setMinimumReserves(1_000_000 * 10 ** 6);
+
+    // Warp time to execute withdrawal
+    vm.warp(block.timestamp + 4 days);
+
+    // Withdrawal should still complete (was scheduled before reserves increased)
+    uint256 usdcBefore = _usdcToken.balanceOf(_owner);
+    _psm.withdraw();
+    uint256 usdcAfter = _usdcToken.balanceOf(_owner);
+
+    assertGt(usdcAfter, usdcBefore, 'User should have received USDC');
+  }
+
+  function testFuzz_MinimumReservesEnforcement(
+    uint256 depositAmount,
+    uint256 minReserves,
+    uint256 withdrawAmount
+  ) public {
+    // Bound inputs to reasonable ranges
+    depositAmount = bound(depositAmount, 10 * 10 ** 6, 100_000 * 10 ** 6);
+    minReserves = bound(minReserves, 0, depositAmount);
+    withdrawAmount = bound(withdrawAmount, 1 * 10 ** 18, depositAmount * 10 ** 12);
+
+    // Deposit
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Set minimum reserves
+    _psm.setMinimumReserves(minReserves);
+
+    uint256 available = _psm.availableForWithdrawal();
+    uint256 withdrawInUnderlying = withdrawAmount / 10 ** 12;
+
+    // Deal MAI to owner so they have enough for the withdrawal attempt
+    // (deposit may give less MAI than withdrawAmount due to fees)
+    // Note: _dealToken stops the prank, so we need to restart it
+    _dealToken(address(_maiToken), _owner, withdrawAmount);
+    vm.startPrank(_owner);
+    _maiToken.approve(address(_psm), withdrawAmount);
+
+    uint256 _feeCheck = _psm.calculateFee(withdrawInUnderlying, false);
+    if (withdrawInUnderlying <= _feeCheck) {
+      // Dust amount: USDC equivalent consumed by fee floor
+      vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmountAfterFee.selector);
+      _psm.scheduleWithdraw(withdrawAmount);
+    } else if (withdrawInUnderlying > available) {
+      // Should revert
+      vm.expectRevert(BeefyVaultPSMMainnet.MinimumReservesBreached.selector);
+      _psm.scheduleWithdraw(withdrawAmount);
+    } else if (withdrawAmount < _psm.minimumWithdrawalFee()) {
+      // Should revert for invalid amount
+      vm.expectRevert(BeefyVaultPSMMainnet.InvalidAmount.selector);
+      _psm.scheduleWithdraw(withdrawAmount);
+    } else {
+      // Should succeed
+      _psm.scheduleWithdraw(withdrawAmount);
+      assertEq(_psm.scheduledWithdrawalAmount(_owner), withdrawAmount);
+    }
+  }
+}
+
+contract PsmMainnetAvailableForWithdrawalView is MainnetIntegrationBase {
+  function test_AvailableForWithdrawalInitiallyZero() public {
+    assertEq(_psm.availableForWithdrawal(), 0);
+  }
+
+  function test_AvailableForWithdrawalAfterDeposit() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 expectedAvailable = depositAmount - fee;
+
+    assertEq(_psm.availableForWithdrawal(), expectedAvailable);
+  }
+
+  function test_AvailableForWithdrawalWithMinimumReserves() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    _psm.setMinimumReserves(300 * 10 ** 6);
+
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 expectedAvailable = depositAmount - fee - 300 * 10 ** 6;
+
+    assertEq(_psm.availableForWithdrawal(), expectedAvailable);
+  }
+
+  function test_AvailableForWithdrawalReturnsZeroWhenBelowMinimum() public {
+    uint256 depositAmount = 100 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    _psm.setMinimumReserves(500 * 10 ** 6);
+
+    assertEq(_psm.availableForWithdrawal(), 0);
+  }
+
+  function test_AvailableForWithdrawalInMAIDecimals() public {
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 availableUSDC = _psm.availableForWithdrawal();
+    uint256 availableMAI = _psm.availableForWithdrawalInMAI();
+
+    assertEq(availableMAI, availableUSDC * 10 ** 12);
+  }
+
+  function test_AvailableForWithdrawalWithQueuedLiquidity() public {
+    uint256 depositAmount = 2000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    // Schedule a withdrawal
+    uint256 withdrawMAI = 500 * 10 ** 18;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Set minimum reserves
+    _psm.setMinimumReserves(300 * 10 ** 6);
+
+    // Available = totalStable - queued - minReserves
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 totalStable = depositAmount - fee;
+    uint256 queued = 500 * 10 ** 6;
+    uint256 minReserves = 300 * 10 ** 6;
+    uint256 expectedAvailable = totalStable - queued - minReserves;
+
+    assertEq(_psm.availableForWithdrawal(), expectedAvailable);
+  }
+
+  function testFuzz_AvailableForWithdrawal(
+    uint256 depositAmount,
+    uint256 minReserves,
+    uint256 queueAmount
+  ) public {
+    depositAmount = bound(depositAmount, 10 * 10 ** 6, 100_000 * 10 ** 6);
+
+    _usdcToken.approve(address(_psm), depositAmount);
+    _psm.deposit(depositAmount);
+
+    uint256 fee = _psm.calculateFee(depositAmount, true);
+    uint256 totalStable = depositAmount - fee;
+
+    // Only queue if we have liquidity
+    queueAmount = bound(queueAmount, 0, totalStable / 2);
+    if (queueAmount >= _psm.minimumWithdrawalFee() / 10 ** 12) {
+      uint256 queueMAI = queueAmount * 10 ** 12;
+      _maiToken.approve(address(_psm), queueMAI);
+      if (queueMAI >= _psm.minimumWithdrawalFee()) {
+        _psm.scheduleWithdraw(queueMAI);
+      }
+    }
+
+    uint256 queued = _psm.totalQueuedLiquidity();
+    minReserves = bound(minReserves, 0, totalStable);
+    _psm.setMinimumReserves(minReserves);
+
+    uint256 available = _psm.availableForWithdrawal();
+    uint256 liquidity = totalStable - queued;
+
+    if (liquidity <= minReserves) {
+      assertEq(available, 0, 'Available should be 0 when liquidity <= minReserves');
+    } else {
+      assertEq(available, liquidity - minReserves, 'Available calculation incorrect');
+    }
+  }
+}
+
+contract PsmMainnetAdminSuite is MainnetIntegrationBase {
+  function test_TransferOwnership() public {
+    vm.expectRevert(BeefyVaultPSMMainnet.NewOwnerCannotBeZeroAddress.selector);
+    _psm.transferOwnership(address(0x0));
+
+    _psm.transferOwnership(address(_user));
+    assertEq(_psm.owner(), address(_user));
+
+    vm.expectRevert(BeefyVaultPSMMainnet.CallerIsNotOwner.selector);
+    _psm.transferOwnership(address(0));
+  }
+
+  function test_Pausing() public {
+    _psm.setPaused(BeefyVaultPSMMainnet.deposit.selector, true);
+
+    _usdcToken.approve(address(_psm), 1000 * 10 ** 6);
+    vm.expectRevert(BeefyVaultPSMMainnet.ContractIsPaused.selector);
+    _psm.deposit(1000 * 10 ** 6);
+  }
+
+  function test_UpdateFeesBP() public {
+    assertEq(_psm.depositFee(), 100);
+    assertEq(_psm.withdrawalFee(), 100);
+
+    _psm.updateFeesBP(200, 200);
+
+    assertEq(_psm.depositFee(), 200);
+    assertEq(_psm.withdrawalFee(), 200);
+  }
+
+  function test_UpdateMinimumFees() public {
+    _psm.updateMinimumFees(200, 200);
+    assertEq(_psm.minimumDepositFee(), 200);
+    assertEq(_psm.minimumWithdrawalFee(), 200);
+  }
+
+  function test_UpdateMax() public {
+    _psm.updateMax(200, 3000);
+    assertEq(_psm.maxDeposit(), 200);
+    assertEq(_psm.maxWithdraw(), 3000);
+  }
+}
+
+contract PsmMainnetDepositWithdrawCycle is MainnetIntegrationBase {
+  function test_FullDepositWithdrawCycleWithMinReserves() public {
+    // Set minimum reserves
+    _psm.setMinimumReserves(100 * 10 ** 6);
+
+    // Deposit 1000 USDC
+    uint256 depositAmount = 1000 * 10 ** 6;
+    _usdcToken.approve(address(_psm), depositAmount);
+
+    uint256 maiBalanceBefore = _maiToken.balanceOf(_owner);
+    _psm.deposit(depositAmount);
+    uint256 maiBalanceAfter = _maiToken.balanceOf(_owner);
+
+    uint256 maiReceived = maiBalanceAfter - maiBalanceBefore;
+    console.log('MAI received from deposit:', maiReceived);
+
+    // Schedule withdrawal (should respect minimum reserves)
+    uint256 available = _psm.availableForWithdrawal();
+    console.log('Available for withdrawal:', available);
+
+    uint256 withdrawMAI = available * 10 ** 12;
+    _maiToken.approve(address(_psm), withdrawMAI);
+    _psm.scheduleWithdraw(withdrawMAI);
+
+    // Verify queued correctly
+    assertEq(_psm.scheduledWithdrawalAmount(_owner), withdrawMAI);
+    assertEq(_psm.totalQueuedLiquidity(), available);
+
+    // Warp time
+    vm.warp(block.timestamp + 4 days);
+
+    // Execute withdrawal
+    uint256 usdcBefore = _usdcToken.balanceOf(_owner);
+    _psm.withdraw();
+    uint256 usdcAfter = _usdcToken.balanceOf(_owner);
+
+    console.log('USDC received from withdrawal:', usdcAfter - usdcBefore);
+    assertGt(usdcAfter, usdcBefore, 'Should have received USDC');
+
+    // Verify remaining liquidity respects minimum reserves
+    uint256 remainingLiquidity = _psm.totalStableLiquidity() - _psm.totalQueuedLiquidity();
+    console.log('Remaining liquidity:', remainingLiquidity);
+    assertGe(remainingLiquidity, _psm.minimumReserves(), 'Remaining should be >= minimum reserves');
+  }
+}

--- a/solidity/test/unit/BeefyVaultW.sol
+++ b/solidity/test/unit/BeefyVaultW.sol
@@ -185,7 +185,9 @@ contract PsmDepositSuite is PsmWithdrawalConstructor {
     _psm.deposit(_amount);
   }
 
-  function test_Deposit(uint256 _amount) public {
+  function test_Deposit(
+    uint256 _amount
+  ) public {
     bound(_amount, 0, _usdbcToken.balanceOf(msg.sender));
     // Verify that the deposit amount is within the allowed range for deposits
     uint256 maxDeposit = _psm.maxDeposit();
@@ -309,7 +311,10 @@ contract PsmWithdrawSuite is PsmWithdrawalConstructor {
     _psm.withdraw();
   }
 
-  function test_DepositAndWithdraw(uint256 _depositAmount, uint256 _withdrawAmount) public {
+  function test_DepositAndWithdraw(
+    uint256 _depositAmount,
+    uint256 _withdrawAmount
+  ) public {
     _depositAmount = bound(_depositAmount, 1e6, _usdbcToken.balanceOf(_owner));
     _withdrawAmount = bound(_withdrawAmount, 1e18, _depositAmount * 10 ** 12);
     // Deposit first to ensure there are tokens to withdraw
@@ -361,7 +366,14 @@ contract PsmWithdrawSuite is PsmWithdrawalConstructor {
     console.log('=====================================');
 
     // Schedule the withdrawal
-    if (_withdrawAmount < _psm.minimumWithdrawalFee() || _withdrawAmount > _psm.maxWithdraw()) {
+    uint256 _toWithdrawCheck = _withdrawAmount / 1e12;
+    uint256 _feeCheck = _psm.calculateFee(_toWithdrawCheck, false);
+    if (_toWithdrawCheck <= _feeCheck) {
+      console.log('Withdraw amount rounds to dust after fee');
+      vm.expectRevert(BeefyVaultPSM.InvalidAmountAfterFee.selector);
+      _psm.scheduleWithdraw(_withdrawAmount);
+      return;
+    } else if (_withdrawAmount < _psm.minimumWithdrawalFee() || _withdrawAmount > _psm.maxWithdraw()) {
       console.log('Withdraw Amount too small or too large');
       vm.expectRevert(BeefyVaultPSM.InvalidAmount.selector);
       _psm.scheduleWithdraw(_withdrawAmount);

--- a/solidity/test/unit/MorphoVaultPSMEvacuateAndSweep.t.sol
+++ b/solidity/test/unit/MorphoVaultPSMEvacuateAndSweep.t.sol
@@ -1,0 +1,1087 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {Test} from 'forge-std/Test.sol';
+import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
+import {MorphoVaultPSM} from 'contracts/MorphoVaultPSM.sol';
+import {IFly} from '../../interfaces/IFly.sol';
+import {console} from 'forge-std/console.sol';
+
+/// @title RevertingMockVault
+/// @notice ERC4626 mock that reverts on redeem — for testing evacuateVault failure path
+contract RevertingMockVault {
+  address public underlying;
+  uint8 public decimals = 6;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  bool public shouldRevertOnRedeem = true;
+
+  constructor(
+    address _underlying
+  ) {
+    underlying = _underlying;
+  }
+
+  function asset() external view returns (address) {
+    return underlying;
+  }
+
+  function deposit(
+    uint256 assets,
+    address receiver
+  ) external returns (uint256) {
+    IERC20(underlying).transferFrom(msg.sender, address(this), assets);
+    balanceOf[receiver] += assets;
+    totalSupply += assets;
+    return assets;
+  }
+
+  function redeem(
+    uint256,
+    address,
+    address
+  ) external view returns (uint256) {
+    if (shouldRevertOnRedeem) revert('VAULT_COMPROMISED');
+    return 0;
+  }
+
+  function convertToAssets(
+    uint256 shares
+  ) external pure returns (uint256) {
+    return shares;
+  }
+
+  function approve(
+    address spender,
+    uint256 amount
+  ) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+}
+
+/// @title MorphoVaultPSMEvacuateAndSweepTest
+/// @notice Unit tests for evacuateVault, claimRefund, sweep, and guardian role
+/// @dev Fork tests targeting Base chain with real Morpho Gauntlet vault
+contract MorphoVaultPSMEvacuateAndSweepTest is Test {
+  // Re-declare events for expectEmit
+  event VaultEvacuated(address indexed _caller, uint256 _sharesRedeemed);
+  event Swept(address indexed _caller, uint256 _amount);
+  event RefundClaimed(address indexed _user, uint256 _maiAmount);
+  event GuardianUpdated(address _guardian, bool _enabled);
+
+  MorphoVaultPSM internal psm;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+  address internal user1 = makeAddr('user1');
+  address internal user2 = makeAddr('user2');
+  address internal random = makeAddr('random');
+
+  // Base chain addresses
+  address internal constant MORPHO_GAUNTLET = 0xc0c5689e6f4D256E861F65465b691aeEcC0dEb12;
+  address internal constant MAI_BASE = 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE;
+  address internal constant USDC_BASE = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+  IERC20 internal usdcToken = IERC20(USDC_BASE);
+  IERC20 internal maiToken = IERC20(MAI_BASE);
+  IFly internal morphoVault = IFly(MORPHO_GAUNTLET);
+
+  function _dealUSDC(
+    address to,
+    uint256 amount
+  ) internal {
+    // Base USDC uses slot 9 for balances (same as mainnet USDC proxy)
+    bytes32 storageSlot = keccak256(abi.encode(to, uint256(9)));
+    vm.store(USDC_BASE, storageSlot, bytes32(amount));
+  }
+
+  function _dealMAI(
+    address to,
+    uint256 amount
+  ) internal {
+    // Use deal cheatcode for MAI on Base
+    deal(MAI_BASE, to, amount);
+  }
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('base'));
+
+    vm.startPrank(owner);
+    psm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    // Fund PSM with MAI for deposits
+    _dealMAI(address(psm), 5_000_000 * 10 ** 18);
+
+    // Fund users with USDC
+    _dealUSDC(user1, 1_000_000 * 10 ** 6);
+    _dealUSDC(user2, 1_000_000 * 10 ** 6);
+
+    // Initialize PSM: 0% deposit fee, 30 bps withdrawal fee
+    vm.startPrank(owner);
+    psm.initialize(MORPHO_GAUNTLET, 0, 30, MAI_BASE);
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Helper: deposit USDC into PSM as a user
+  // ═══════════════════════════════════════════════════════════
+
+  function _depositAs(
+    address user,
+    uint256 amount
+  ) internal {
+    vm.startPrank(user);
+    usdcToken.approve(address(psm), amount);
+    psm.deposit(amount);
+    vm.stopPrank();
+  }
+
+  function _scheduleWithdrawAs(
+    address user,
+    uint256 maiAmount
+  ) internal {
+    vm.startPrank(user);
+    maiToken.approve(address(psm), maiAmount);
+    psm.scheduleWithdraw(maiAmount);
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  evacuateVault tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_evacuateVault_happyPath() public {
+    // Deposit some USDC first
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    uint256 vaultSharesBefore = morphoVault.balanceOf(address(psm));
+    assertGt(vaultSharesBefore, 0, 'PSM should have vault shares');
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertTrue(psm.evacuated(), 'Should be evacuated');
+    assertTrue(psm.stopped(), 'Should be stopped');
+    assertGt(psm.upgradeTime(), block.timestamp, 'Upgrade time should be in future');
+    assertEq(morphoVault.balanceOf(address(psm)), 0, 'Vault shares should be 0');
+    assertGt(usdcToken.balanceOf(address(psm)), 0, 'PSM should hold USDC');
+  }
+
+  function test_evacuateVault_ownerCanCall() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    vm.prank(owner);
+    psm.evacuateVault();
+
+    assertTrue(psm.evacuated());
+  }
+
+  function test_evacuateVault_guardianCanCall() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertTrue(psm.evacuated());
+  }
+
+  function test_evacuateVault_randomAddressReverts() public {
+    vm.prank(random);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotGuardianOrOwner.selector);
+    psm.evacuateVault();
+  }
+
+  function test_evacuateVault_idempotent() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    uint256 usdcAfterFirst = usdcToken.balanceOf(address(psm));
+
+    // Call again — should not revert
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertTrue(psm.evacuated());
+    assertEq(usdcToken.balanceOf(address(psm)), usdcAfterFirst, 'USDC balance should not change');
+  }
+
+  function test_evacuateVault_doesNotResetUpgradeTime() public {
+    // First call setUpgrade
+    vm.prank(owner);
+    psm.setUpgrade();
+    uint256 originalUpgradeTime = psm.upgradeTime();
+
+    // Then evacuate — should not reset upgradeTime
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertEq(psm.upgradeTime(), originalUpgradeTime, 'upgradeTime should not be reset');
+  }
+
+  function test_evacuateVault_freezesContractImmediately() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // deposit should revert
+    _dealUSDC(user2, 10_000 * 10 ** 6);
+    vm.startPrank(user2);
+    usdcToken.approve(address(psm), 10_000 * 10 ** 6);
+    vm.expectRevert(MorphoVaultPSM.ContractIsPaused.selector);
+    psm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+
+    // scheduleWithdraw should revert
+    _dealMAI(user2, 10_000 * 10 ** 18);
+    vm.startPrank(user2);
+    maiToken.approve(address(psm), 10_000 * 10 ** 18);
+    vm.expectRevert(MorphoVaultPSM.ContractIsPaused.selector);
+    psm.scheduleWithdraw(10_000 * 10 ** 18);
+    vm.stopPrank();
+  }
+
+  function test_evacuateVault_freezesWithdraw() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    // Schedule a withdrawal
+    uint256 maiAmount = 5000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    // Warp past withdrawal epoch
+    vm.warp(block.timestamp + 4 days);
+
+    // Evacuate
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // withdraw should revert even though epoch passed
+    vm.prank(user1);
+    vm.expectRevert(MorphoVaultPSM.ContractIsPaused.selector);
+    psm.withdraw();
+  }
+
+  function test_evacuateVault_bookkeepingPreserved() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    uint256 stableBefore = psm.totalStableLiquidity();
+    uint256 queuedBefore = psm.totalQueuedLiquidity();
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertEq(psm.totalStableLiquidity(), stableBefore, 'totalStableLiquidity should not change');
+    assertEq(psm.totalQueuedLiquidity(), queuedBefore, 'totalQueuedLiquidity should not change');
+  }
+
+  function test_evacuateVault_emitsEvent() public {
+    _depositAs(user1, 10_000 * 10 ** 6);
+
+    uint256 expectedShares = morphoVault.balanceOf(address(psm));
+
+    vm.prank(guardian);
+    vm.expectEmit(true, false, false, true);
+    emit VaultEvacuated(guardian, expectedShares);
+    psm.evacuateVault();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  claimRefund tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_claimRefund_happyPath() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // Schedule withdrawal
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    uint256 stableBefore = psm.totalStableLiquidity();
+    uint256 queuedBefore = psm.totalQueuedLiquidity();
+
+    // Evacuate
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // Claim refund
+    uint256 maiBalanceBefore = maiToken.balanceOf(user1);
+    vm.prank(user1);
+    psm.claimRefund();
+
+    // User got MAI back
+    assertEq(maiToken.balanceOf(user1), maiBalanceBefore + maiAmount, 'Should receive MAI back');
+
+    // Bookkeeping updated
+    uint256 toRefund = maiAmount / (10 ** 12); // decimalDifference = 12
+    assertEq(psm.totalStableLiquidity(), stableBefore - toRefund, 'totalStableLiquidity decreased');
+    assertEq(psm.totalQueuedLiquidity(), queuedBefore - toRefund, 'totalQueuedLiquidity decreased');
+
+    // Mappings cleared
+    assertEq(psm.scheduledWithdrawalAmount(user1), 0, 'scheduledWithdrawalAmount cleared');
+    assertEq(psm.withdrawalEpoch(user1), 0, 'withdrawalEpoch cleared');
+  }
+
+  function test_claimRefund_revertsWhenNotEvacuated() public {
+    vm.prank(user1);
+    vm.expectRevert(MorphoVaultPSM.NotEvacuated.selector);
+    psm.claimRefund();
+  }
+
+  function test_claimRefund_revertsWhenNoPendingWithdrawal() public {
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    vm.prank(user1);
+    vm.expectRevert(MorphoVaultPSM.NoWithdrawalScheduled.selector);
+    psm.claimRefund();
+  }
+
+  function test_claimRefund_revertsOnDoubleClaim() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    vm.prank(user1);
+    psm.claimRefund();
+
+    vm.prank(user1);
+    vm.expectRevert(MorphoVaultPSM.NoWithdrawalScheduled.selector);
+    psm.claimRefund();
+  }
+
+  function test_claimRefund_multipleUsers() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+    _depositAs(user2, 100_000 * 10 ** 6);
+
+    uint256 mai1 = 30_000 * 10 ** 18;
+    uint256 mai2 = 20_000 * 10 ** 18;
+    _dealMAI(user1, mai1);
+    _dealMAI(user2, mai2);
+    _scheduleWithdrawAs(user1, mai1);
+    _scheduleWithdrawAs(user2, mai2);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    vm.prank(user1);
+    psm.claimRefund();
+
+    vm.prank(user2);
+    psm.claimRefund();
+
+    assertEq(psm.totalQueuedLiquidity(), 0, 'All queued liquidity should be drained');
+  }
+
+  function test_claimRefund_emitsEvent() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    vm.prank(user1);
+    vm.expectEmit(true, false, false, true);
+    emit RefundClaimed(user1, maiAmount);
+    psm.claimRefund();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  sweep tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_sweep_happyPath() public {
+    // Send USDC directly to the contract (simulating migration)
+    uint256 sweepAmount = 50_000 * 10 ** 6;
+    _dealUSDC(address(psm), sweepAmount);
+
+    uint256 stableBefore = psm.totalStableLiquidity();
+    uint256 vaultSharesBefore = morphoVault.balanceOf(address(psm));
+
+    vm.prank(owner);
+    psm.sweep();
+
+    assertEq(psm.totalStableLiquidity(), stableBefore + sweepAmount, 'totalStableLiquidity increased by swept amount');
+    assertGt(morphoVault.balanceOf(address(psm)), vaultSharesBefore, 'Vault shares should increase');
+    assertEq(usdcToken.balanceOf(address(psm)), 0, 'No idle USDC should remain');
+  }
+
+  function test_sweep_revertsOnZeroBalance() public {
+    vm.prank(owner);
+    vm.expectRevert(MorphoVaultPSM.InvalidAmount.selector);
+    psm.sweep();
+  }
+
+  function test_sweep_revertsWhenEvacuated() public {
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    _dealUSDC(address(psm), 10_000 * 10 ** 6);
+
+    vm.prank(owner);
+    vm.expectRevert(MorphoVaultPSM.ContractIsPaused.selector);
+    psm.sweep();
+  }
+
+  function test_sweep_revertsForNonOwner() public {
+    _dealUSDC(address(psm), 10_000 * 10 ** 6);
+
+    vm.prank(random);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotOwner.selector);
+    psm.sweep();
+  }
+
+  function test_sweep_thenNormalWithdrawWorks() public {
+    // Deposit first to create some base liquidity
+    _depositAs(user1, 50_000 * 10 ** 6);
+
+    // Sweep additional USDC
+    uint256 sweepAmount = 50_000 * 10 ** 6;
+    _dealUSDC(address(psm), sweepAmount);
+    vm.prank(owner);
+    psm.sweep();
+
+    // User should be able to schedule withdrawal for more than original deposit
+    uint256 maiAmount = 80_000 * 10 ** 18; // 80k MAI (more than 50k deposit but less than 100k total)
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    // Warp and withdraw
+    vm.warp(block.timestamp + 4 days);
+    vm.prank(user1);
+    psm.withdraw();
+
+    // Should succeed — bookkeeping is consistent
+    assertGt(usdcToken.balanceOf(user1), 0, 'User should have received USDC');
+  }
+
+  function test_sweep_thenClaimFeesWorks() public {
+    // Deposit to create base liquidity
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // Sweep additional USDC
+    uint256 sweepAmount = 10_000 * 10 ** 6;
+    _dealUSDC(address(psm), sweepAmount);
+    vm.prank(owner);
+    psm.sweep();
+
+    // Warp to accumulate some yield
+    vm.warp(block.timestamp + 30 days);
+
+    // ClaimFees should work — vault assets > totalStableLiquidity from yield
+    uint256 ownerUsdcBefore = usdcToken.balanceOf(owner);
+    vm.prank(owner);
+    psm.claimFees();
+
+    // If yield accumulated, owner should receive something
+    // (might be 0 if no yield in 30 days on fork — that's ok, just shouldn't revert)
+  }
+
+  function test_sweep_emitsEvent() public {
+    uint256 sweepAmount = 50_000 * 10 ** 6;
+    _dealUSDC(address(psm), sweepAmount);
+
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, true);
+    emit Swept(owner, sweepAmount);
+    psm.sweep();
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  guardian tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_setGuardian_ownerCanSet() public {
+    address newGuardian = makeAddr('newGuardian');
+    vm.prank(owner);
+    psm.setGuardian(newGuardian, true);
+    assertTrue(psm.guardians(newGuardian));
+  }
+
+  function test_setGuardian_ownerCanRevoke() public {
+    vm.prank(owner);
+    psm.setGuardian(guardian, false);
+    assertFalse(psm.guardians(guardian));
+  }
+
+  function test_setGuardian_nonOwnerReverts() public {
+    vm.prank(random);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotOwner.selector);
+    psm.setGuardian(random, true);
+  }
+
+  function test_guardian_cannotCallSweep() public {
+    _dealUSDC(address(psm), 10_000 * 10 ** 6);
+    vm.prank(guardian);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotOwner.selector);
+    psm.sweep();
+  }
+
+  function test_guardian_cannotCallClaimFees() public {
+    vm.prank(guardian);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotOwner.selector);
+    psm.claimFees();
+  }
+
+  function test_setGuardian_emitsEvent() public {
+    address newGuardian = makeAddr('newGuardian');
+    vm.prank(owner);
+    vm.expectEmit(false, false, false, true);
+    emit GuardianUpdated(newGuardian, true);
+    psm.setGuardian(newGuardian, true);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  multi-guardian tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_setGuardian_addMultipleGuardians() public {
+    address guardian2 = makeAddr('guardian2');
+    vm.startPrank(owner);
+    psm.setGuardian(guardian2, true);
+    vm.stopPrank();
+
+    assertTrue(psm.guardians(guardian));
+    assertTrue(psm.guardians(guardian2));
+
+    // Both can independently evacuate (only first succeeds, second is idempotent)
+    _depositAs(user1, 10_000 * 10 ** 6);
+    vm.prank(guardian);
+    psm.evacuateVault();
+    assertTrue(psm.evacuated());
+
+    // guardian2 can also call (idempotent)
+    vm.prank(guardian2);
+    psm.evacuateVault();
+  }
+
+  function test_setGuardian_removeOneGuardianOtherRetainsAccess() public {
+    address guardian2 = makeAddr('guardian2');
+    vm.startPrank(owner);
+    psm.setGuardian(guardian2, true);
+    psm.setGuardian(guardian, false);
+    vm.stopPrank();
+
+    assertFalse(psm.guardians(guardian));
+    assertTrue(psm.guardians(guardian2));
+
+    // Removed guardian reverts
+    vm.prank(guardian);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotGuardianOrOwner.selector);
+    psm.evacuateVault();
+
+    // Remaining guardian succeeds
+    vm.prank(guardian2);
+    psm.evacuateVault();
+    assertTrue(psm.evacuated());
+  }
+
+  function test_setGuardian_removeGuardianPreventsEvacuate() public {
+    vm.prank(owner);
+    psm.setGuardian(guardian, false);
+
+    vm.prank(guardian);
+    vm.expectRevert(MorphoVaultPSM.CallerIsNotGuardianOrOwner.selector);
+    psm.evacuateVault();
+  }
+
+  function test_setGuardian_readdRemovedGuardian() public {
+    vm.startPrank(owner);
+    psm.setGuardian(guardian, false);
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+
+    assertTrue(psm.guardians(guardian));
+
+    // Re-added guardian can evacuate
+    vm.prank(guardian);
+    psm.evacuateVault();
+    assertTrue(psm.evacuated());
+  }
+
+  function test_setGuardian_addressZeroReverts() public {
+    vm.prank(owner);
+    vm.expectRevert(MorphoVaultPSM.GuardianCannotBeZeroAddress.selector);
+    psm.setGuardian(address(0), true);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  MAI protection post-evacuation tests
+  // ═══════════════════════════════════════════════════════════
+
+  function test_withdrawMAI_protectsRefundsPostEvacuation() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // Schedule withdrawal for 50k MAI
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    uint256 maiBalance = maiToken.balanceOf(address(psm));
+    uint256 reserved = psm.totalQueuedMAI();
+
+    // Owner withdraws MAI — should only get excess, not reserved
+    vm.prank(owner);
+    psm.withdrawMAI();
+
+    uint256 ownerMai = maiToken.balanceOf(owner);
+    uint256 psmMaiAfter = maiToken.balanceOf(address(psm));
+
+    assertGe(psmMaiAfter, reserved, 'PSM should retain at least reserved MAI');
+    assertEq(ownerMai, maiBalance - reserved, 'Owner gets only the excess');
+  }
+
+  function test_withdrawMAI_normalBehaviorPreEvacuation() public {
+    uint256 maiBalance = maiToken.balanceOf(address(psm));
+
+    vm.prank(owner);
+    psm.withdrawMAI();
+
+    assertEq(maiToken.balanceOf(owner), maiBalance, 'Owner gets all MAI pre-evacuation');
+    assertEq(maiToken.balanceOf(address(psm)), 0, 'PSM should have 0 MAI');
+  }
+
+  function test_transferToken_gatesUnderlyingPostEvacuation() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    uint256 usdcInPsm = usdcToken.balanceOf(address(psm));
+    assertGt(usdcInPsm, 0, 'PSM should have USDC');
+
+    // Immediately after evacuation — underlying should be gated
+    vm.prank(owner);
+    vm.expectRevert(MorphoVaultPSM.UpgradeNotScheduled.selector);
+    psm.transferToken(USDC_BASE, owner, usdcInPsm);
+  }
+
+  function test_transferToken_underlyingWorksAfter2Days() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    uint256 usdcInPsm = usdcToken.balanceOf(address(psm));
+
+    // Warp past 2-day upgrade delay
+    vm.warp(block.timestamp + 2 days + 1);
+
+    vm.prank(owner);
+    psm.transferToken(USDC_BASE, owner, usdcInPsm);
+
+    assertEq(usdcToken.balanceOf(owner), usdcInPsm, 'Owner should receive USDC after delay');
+  }
+
+  function test_transferToken_underlyingWorksImmediatelyPreEvacuation() public {
+    // Send USDC directly to PSM (not through deposit)
+    _dealUSDC(address(psm), 10_000 * 10 ** 6);
+
+    vm.prank(owner);
+    psm.transferToken(USDC_BASE, owner, 10_000 * 10 ** 6);
+
+    assertEq(usdcToken.balanceOf(owner), 10_000 * 10 ** 6, 'Owner gets USDC immediately pre-evacuation');
+  }
+
+  function test_transferToken_protectsMAIPostEvacuation() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    uint256 maiBalance = maiToken.balanceOf(address(psm));
+
+    // Try to transfer more MAI than available (excess of reserved)
+    vm.prank(owner);
+    vm.expectRevert(MorphoVaultPSM.NotEnoughLiquidity.selector);
+    psm.transferToken(MAI_BASE, owner, maiBalance);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Edge case: evacuate with queued withdrawals
+  // ═══════════════════════════════════════════════════════════
+
+  function test_evacuateWithQueuedWithdrawals_fullFlow() public {
+    // User1 deposits
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // User1 schedules withdrawal
+    uint256 maiAmount = 50_000 * 10 ** 18;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    uint256 stableBefore = psm.totalStableLiquidity();
+    uint256 queuedBefore = psm.totalQueuedLiquidity();
+    assertGt(queuedBefore, 0, 'Should have queued liquidity');
+
+    // Evacuate
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // Bookkeeping unchanged by evacuation
+    assertEq(psm.totalStableLiquidity(), stableBefore);
+    assertEq(psm.totalQueuedLiquidity(), queuedBefore);
+
+    // User claims refund
+    vm.prank(user1);
+    psm.claimRefund();
+
+    // Final state
+    uint256 refundedUsdc = maiAmount / (10 ** 12);
+    assertEq(psm.totalStableLiquidity(), stableBefore - refundedUsdc);
+    assertEq(psm.totalQueuedLiquidity(), 0);
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Invariant: totalStableLiquidity >= totalQueuedLiquidity
+  // ═══════════════════════════════════════════════════════════
+
+  function test_invariant_stableGteQueued_afterEvacuateAndRefund() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+    _depositAs(user2, 50_000 * 10 ** 6);
+
+    uint256 mai1 = 40_000 * 10 ** 18;
+    uint256 mai2 = 30_000 * 10 ** 18;
+    _dealMAI(user1, mai1);
+    _dealMAI(user2, mai2);
+    _scheduleWithdrawAs(user1, mai1);
+    _scheduleWithdrawAs(user2, mai2);
+
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    assertGe(psm.totalStableLiquidity(), psm.totalQueuedLiquidity(), 'Invariant before refunds');
+
+    vm.prank(user1);
+    psm.claimRefund();
+    assertGe(psm.totalStableLiquidity(), psm.totalQueuedLiquidity(), 'Invariant after user1 refund');
+
+    vm.prank(user2);
+    psm.claimRefund();
+    assertGe(psm.totalStableLiquidity(), psm.totalQueuedLiquidity(), 'Invariant after user2 refund');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Truncation regression: non-round MAI amount
+  // ═══════════════════════════════════════════════════════════
+
+  function test_totalQueuedMAI_tracksExactAmount_withTruncation() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // Schedule withdrawal with a non-round MAI amount that causes truncation
+    // 40_000e18 + 1 wei: the +1 gets truncated by / 10^12 in totalQueuedLiquidity
+    // but totalQueuedMAI must track the full amount
+    uint256 maiAmount = 40_000 * 10 ** 18 + 1;
+    _dealMAI(user1, maiAmount);
+    _scheduleWithdrawAs(user1, maiAmount);
+
+    // totalQueuedLiquidity truncates: (40_000e18 + 1) / 1e12 = 40_000e6 (truncated)
+    assertEq(psm.totalQueuedLiquidity(), 40_000 * 10 ** 6, 'Truncated USDC value');
+    // totalQueuedMAI tracks exact amount
+    assertEq(psm.totalQueuedMAI(), maiAmount, 'Exact MAI tracked');
+
+    // Evacuate and verify the owner cannot drain the exact MAI needed
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // Owner withdraws excess MAI — must leave the full maiAmount, not the truncated value
+    vm.prank(owner);
+    psm.withdrawMAI();
+
+    uint256 psmMaiAfter = maiToken.balanceOf(address(psm));
+    assertGe(psmMaiAfter, maiAmount, 'PSM retains exact MAI for refund, not truncated amount');
+
+    // User can claim the full amount
+    vm.prank(user1);
+    psm.claimRefund();
+    assertEq(psm.totalQueuedMAI(), 0, 'totalQueuedMAI zeroed after refund');
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Withdrawal boundary: rounded amount must exceed the fee floor
+  // ═══════════════════════════════════════════════════════════
+
+  function test_scheduleWithdraw_dustAmount_reverts() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // minimumWithdrawalFee is 1_000_000 underlying units ($1). This MAI amount
+    // rounds to 0 underlying, so it must be rejected before scheduling.
+    uint256 dustMai = 1_000_000; // = minimumWithdrawalFee
+    _dealMAI(user1, dustMai);
+    vm.startPrank(user1);
+    maiToken.approve(address(psm), dustMai);
+
+    vm.expectRevert(MorphoVaultPSM.InvalidAmountAfterFee.selector);
+    psm.scheduleWithdraw(dustMai);
+    vm.stopPrank();
+  }
+
+  function test_scheduleWithdraw_amountConsumedByFee_reverts() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // 1 MAI rounds to exactly 1 USDC, which is then fully consumed by the
+    // minimum withdrawal fee. Scheduling must reject zero-net withdrawals.
+    uint256 oneDollarMai = 1 * 10 ** 18;
+    _dealMAI(user1, oneDollarMai);
+    vm.startPrank(user1);
+    maiToken.approve(address(psm), oneDollarMai);
+
+    vm.expectRevert(MorphoVaultPSM.InvalidAmountAfterFee.selector);
+    psm.scheduleWithdraw(oneDollarMai);
+    vm.stopPrank();
+  }
+
+  function test_scheduleWithdraw_amountAboveFeeBoundary_succeeds() public {
+    _depositAs(user1, 100_000 * 10 ** 6);
+
+    // 1.000001 MAI rounds to 1_000_001 underlying units, leaving 1 unit after
+    // the $1 fee floor. This is the first valid amount above the boundary.
+    uint256 validMai = 1_000_001 * 10 ** 12;
+    _dealMAI(user1, validMai);
+    vm.startPrank(user1);
+    maiToken.approve(address(psm), validMai);
+    psm.scheduleWithdraw(validMai);
+    vm.stopPrank();
+
+    assertEq(psm.totalQueuedLiquidity(), 1_000_001, 'Rounded underlying amount should be queued');
+    assertEq(psm.totalQueuedMAI(), validMai, 'Exact MAI amount should be tracked');
+  }
+}
+
+/// @title MorphoVaultPSMRedeemFailureTest
+/// @notice Tests evacuateVault when the underlying vault reverts on redeem
+contract MorphoVaultPSMRedeemFailureTest is Test {
+  event VaultEvacuated(address indexed _caller, uint256 _sharesRedeemed);
+  event RedeemFailed(bytes _reason);
+
+  MorphoVaultPSM internal psm;
+  RevertingMockVault internal revertVault;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+  address internal user1 = makeAddr('user1');
+
+  // Base chain fork for USDC/MAI
+  address internal constant MAI_BASE = 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE;
+  address internal constant USDC_BASE = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+  IERC20 internal usdcToken = IERC20(USDC_BASE);
+  IERC20 internal maiToken = IERC20(MAI_BASE);
+
+  function _dealUSDC(
+    address to,
+    uint256 amount
+  ) internal {
+    bytes32 storageSlot = keccak256(abi.encode(to, uint256(9)));
+    vm.store(USDC_BASE, storageSlot, bytes32(amount));
+  }
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('base'));
+
+    // Deploy reverting vault
+    revertVault = new RevertingMockVault(USDC_BASE);
+
+    vm.startPrank(owner);
+    psm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    deal(MAI_BASE, address(psm), 5_000_000 * 10 ** 18);
+    _dealUSDC(user1, 1_000_000 * 10 ** 6);
+
+    vm.startPrank(owner);
+    psm.initialize(address(revertVault), 0, 30, MAI_BASE);
+    psm.setGuardian(guardian, true);
+    vm.stopPrank();
+  }
+
+  function test_evacuateVault_freezesEvenWhenRedeemReverts() public {
+    // Deposit USDC — it goes into the reverting vault
+    vm.startPrank(user1);
+    usdcToken.approve(address(psm), 10_000 * 10 ** 6);
+    psm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+
+    uint256 sharesBefore = revertVault.balanceOf(address(psm));
+    assertGt(sharesBefore, 0, 'PSM should have vault shares');
+
+    // Evacuate — redeem will revert, but contract should still freeze
+    vm.prank(guardian);
+    psm.evacuateVault();
+
+    // Contract IS frozen
+    assertTrue(psm.evacuated(), 'Should be evacuated despite redeem failure');
+    assertTrue(psm.stopped(), 'Should be stopped');
+
+    // Shares still in vault (redeem failed)
+    assertEq(revertVault.balanceOf(address(psm)), sharesBefore, 'Shares should remain (redeem failed)');
+
+    // User operations blocked
+    _dealUSDC(user1, 10_000 * 10 ** 6);
+    vm.startPrank(user1);
+    usdcToken.approve(address(psm), 10_000 * 10 ** 6);
+    vm.expectRevert(MorphoVaultPSM.ContractIsPaused.selector);
+    psm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+  }
+
+  function test_evacuateVault_emitsRedeemFailedEvent() public {
+    vm.startPrank(user1);
+    usdcToken.approve(address(psm), 10_000 * 10 ** 6);
+    psm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+
+    // Should emit RedeemFailed with the ABI-encoded revert reason
+    vm.prank(guardian);
+    vm.expectEmit(false, false, false, false);
+    emit RedeemFailed('');
+    psm.evacuateVault();
+
+    assertTrue(psm.evacuated());
+  }
+}
+
+/// @title MorphoVaultPSMMigrationWithRefundsTest
+/// @notice E2E migration test with queued withdrawals and refunds mid-migration
+contract MorphoVaultPSMMigrationWithRefundsTest is Test {
+  MorphoVaultPSM internal oldPsm;
+  MorphoVaultPSM internal newPsm;
+
+  address internal owner = makeAddr('owner');
+  address internal guardian = makeAddr('guardian');
+  address internal user1 = makeAddr('user1');
+  address internal user2 = makeAddr('user2');
+
+  address internal constant MORPHO_GAUNTLET = 0xc0c5689e6f4D256E861F65465b691aeEcC0dEb12;
+  address internal constant MAI_BASE = 0xbf1aeA8670D2528E08334083616dD9C5F3B087aE;
+  address internal constant USDC_BASE = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+  IERC20 internal usdc = IERC20(USDC_BASE);
+  IERC20 internal mai = IERC20(MAI_BASE);
+
+  function _dealUSDC(
+    address to,
+    uint256 amount
+  ) internal {
+    bytes32 storageSlot = keccak256(abi.encode(to, uint256(9)));
+    vm.store(USDC_BASE, storageSlot, bytes32(amount));
+  }
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('base'));
+
+    _dealUSDC(user1, 1_000_000 * 10 ** 6);
+    _dealUSDC(user2, 1_000_000 * 10 ** 6);
+
+    vm.startPrank(owner);
+    oldPsm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    deal(MAI_BASE, address(oldPsm), 10_000_000 * 10 ** 18);
+
+    vm.startPrank(owner);
+    oldPsm.initialize(MORPHO_GAUNTLET, 0, 30, MAI_BASE);
+    oldPsm.setGuardian(guardian, true);
+    vm.stopPrank();
+  }
+
+  function test_migrationWithQueuedWithdrawalsAndRefunds() public {
+    // Step 1: Users deposit
+    vm.startPrank(user1);
+    usdc.approve(address(oldPsm), 100_000 * 10 ** 6);
+    oldPsm.deposit(100_000 * 10 ** 6);
+    vm.stopPrank();
+
+    vm.startPrank(user2);
+    usdc.approve(address(oldPsm), 50_000 * 10 ** 6);
+    oldPsm.deposit(50_000 * 10 ** 6);
+    vm.stopPrank();
+
+    // Step 2: User1 schedules withdrawal (queued)
+    uint256 maiAmount = 40_000 * 10 ** 18;
+    deal(MAI_BASE, user1, maiAmount);
+    vm.startPrank(user1);
+    mai.approve(address(oldPsm), maiAmount);
+    oldPsm.scheduleWithdraw(maiAmount);
+    vm.stopPrank();
+
+    uint256 stableBefore = oldPsm.totalStableLiquidity();
+    uint256 queuedBefore = oldPsm.totalQueuedLiquidity();
+    assertGt(queuedBefore, 0, 'Should have queued liquidity');
+
+    // Step 3: Guardian evacuates
+    vm.prank(guardian);
+    oldPsm.evacuateVault();
+
+    assertTrue(oldPsm.evacuated());
+    uint256 usdcInOldPsm = usdc.balanceOf(address(oldPsm));
+
+    // Step 4: User1 claims MAI refund mid-migration
+    uint256 user1MaiBefore = mai.balanceOf(user1);
+    vm.prank(user1);
+    oldPsm.claimRefund();
+    assertEq(mai.balanceOf(user1), user1MaiBefore + maiAmount, 'User1 got MAI back');
+    assertEq(oldPsm.totalQueuedLiquidity(), 0, 'Queue cleared after refund');
+
+    // Step 5: Wait 2 days for transferToken
+    vm.warp(block.timestamp + 2 days + 1);
+
+    // Step 6: Owner transfers USDC out
+    uint256 usdcToMigrate = usdc.balanceOf(address(oldPsm));
+    vm.prank(owner);
+    oldPsm.transferToken(USDC_BASE, owner, usdcToMigrate);
+
+    // Step 7: Owner also withdraws excess MAI
+    vm.prank(owner);
+    oldPsm.withdrawMAI();
+
+    // Step 8: Deploy new PSM, send USDC, sweep
+    vm.startPrank(owner);
+    newPsm = new MorphoVaultPSM();
+    vm.stopPrank();
+
+    deal(MAI_BASE, address(newPsm), 10_000_000 * 10 ** 18);
+
+    vm.startPrank(owner);
+    newPsm.initialize(MORPHO_GAUNTLET, 0, 30, MAI_BASE);
+    usdc.transfer(address(newPsm), usdcToMigrate);
+    newPsm.sweep();
+    vm.stopPrank();
+
+    // Step 9: Verify new PSM is operational
+    assertEq(newPsm.totalStableLiquidity(), usdcToMigrate, 'New PSM liquidity matches');
+
+    // Step 10: User2 can deposit into new PSM
+    vm.startPrank(user2);
+    usdc.approve(address(newPsm), 10_000 * 10 ** 6);
+    newPsm.deposit(10_000 * 10 ** 6);
+    vm.stopPrank();
+
+    assertGt(newPsm.totalStableLiquidity(), usdcToMigrate, 'New deposits work');
+
+    // Invariants hold throughout
+    assertGe(newPsm.totalStableLiquidity(), newPsm.totalQueuedLiquidity());
+    assertEq(oldPsm.totalQueuedLiquidity(), 0);
+  }
+}


### PR DESCRIPTION
## Summary

Adds an emergency evacuation / sweep / refund pathway to both `MorphoVaultPSM` and `BeefyVaultPSM`, along with a multi-guardian role for privileged operators. Built on top of #3 (`fix/royalaid/test-fixes`) as a stacked PR.

### Commits
- **`99377cc`** — *Mainnet Beefy PSM deployment scripts + integration tests*: deployment tooling for Beefy PSMs on Ethereum mainnet, with fork-based integration tests against real Gauntlet/Steakhouse Morpho vaults on Base.
- **`6de340a`** — *Evacuate/sweep feature across Morpho + Beefy PSMs*:
  - **Core feature:**
    - `evacuateVault`: guardian-triggered withdrawal of idle vault shares back to the PSM, draining the underlying vault cleanly
    - `sweep`: pull evacuated underlying out to a recipient once the PSM is in a fully-settled state
    - `claimRefund`: users with queued withdrawals can reclaim their MAI if the PSM is evacuated before their withdrawal epoch completes
    - `forceSettle` (Beefy): emergency-settle leftover queued MAI once the vault has been drained
    - Multi-guardian role with add/remove lifecycle on both PSMs
  - **Bookkeeping + correctness fixes (from review):**
    - Track exact MAI owed to queued withdrawals via `totalQueuedMAI` so evacuation accounting does not drift against the reserve ledger
    - Reject dust withdrawals whose USDC-equivalent rounds to zero
    - Pin `RedeemFailed` event shape + truncation/dust-boundary regression tests
  - **Tests:**
    - Unit suite for `evacuateVault` / `sweep` / `claimRefund` / guardian on both PSMs
    - Integration tests against real Base Morpho vaults (Gauntlet + Steakhouse) via fork
    - Invariant tests for `MorphoVaultPSM` bookkeeping across normal ops and evacuate/sweep lifecycles

### Stacked PR
Depends on #3. Base branch: `fix/royalaid/test-fixes`. Do not merge until #3 lands or is retargeted to `main`.

## Test plan
- [ ] `FOUNDRY_PROFILE=test forge test` — all feature-specific suites pass (60+ tests: `MorphoVaultPSMEvacuateAndSweepTest`, `MorphoEvacuateSweepIntegrationTest`, `MorphoVaultPSMInvariantTest`, etc.)
- [ ] Review the evacuation safety properties under adversarial guardian / timing scenarios

> **CI note:** Same pre-existing orphan-file build failures on `main` apply here (`stableQiVault.sol`, `QiDaoOFT.sol`, OZ ERC20 version mismatch). Not introduced by this PR.